### PR TITLE
Improve tracing under load and graceful trace capture

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -275,10 +275,10 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            type:ref,event=branch
-            type:ref,event=pr
-            type:sha,prefix={{branch}}-
-            type:raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Choose image tag for downstream jobs
         id: set_image

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -277,7 +277,8 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=pr
-            type=sha,prefix={{branch}}-
+            # Short digest tag (valid even when `branch` is empty on some PR/fork flows; avoid `prefix={{branch}}-` → leading `-`).
+            type=sha,format=short,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Choose image tag for downstream jobs

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -289,13 +289,23 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          # Prefer the deterministic sha tag (<ref_name>-<sha>) when present.
-          preferred="ghcr.io/${{ github.repository }}:${REF_NAME}-${SHA}"
-          if echo "$TAGS" | tr -d '\r' | grep -Fxq "$preferred"; then
-            image="$preferred"
+          # docker/metadata-action does not emit `${ref}-${full_40_char_sha}` by default; `type=sha`
+          # yields `sha-<short>`. Match that first, then legacy `ref-fullsha` if ever present.
+          repo="ghcr.io/${{ github.repository }}"
+          short_sha=$(printf '%s' "$SHA" | cut -c1-7)
+          preferred_digest="${repo}:sha-${short_sha}"
+          preferred_ref_fullsha="${repo}:${REF_NAME}-${SHA}"
+          image=""
+          if echo "$TAGS" | tr -d '\r' | grep -Fxq "$preferred_digest"; then
+            image="$preferred_digest"
+          elif echo "$TAGS" | tr -d '\r' | grep -Fxq "$preferred_ref_fullsha"; then
+            image="$preferred_ref_fullsha"
           else
-            # Fallback: first generated tag.
-            image="$(echo "$TAGS" | head -n1 | tr -d '\r')"
+            # PR pipelines: prefer stable `pr-<n>` if metadata produced it.
+            image=$(echo "$TAGS" | tr -d '\r' | grep -E ":pr-[0-9]+\$" | head -n1 || true)
+            if [ -z "${image:-}" ]; then
+              image="$(echo "$TAGS" | head -n1 | tr -d '\r')"
+            fi
           fi
           test -n "$image"
           echo "image=$image" >> "$GITHUB_OUTPUT"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,6 +1430,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-chrome",
+ "tracing-log",
  "tracing-subscriber",
  "twox-hash",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ tracing = "0.1"
 # >=0.3.20 addresses RUSTSEC-2025-0055 (ANSI escapes in logs).
 tracing-subscriber = { version = "0.3.20", features = ["env-filter", "fmt"] }
 tracing-chrome = "0.7"
+tracing-log = "0.2"
 
 # File operations and I/O
 memmap2 = "0.9"

--- a/docs/network/quic-and-quinn.md
+++ b/docs/network/quic-and-quinn.md
@@ -129,6 +129,8 @@ cargo run -- server --host 127.0.0.1 --port 5432 --cert-out server.der
 
 Open `target/rustdb-chrome-trace.json` in `chrome://tracing` (Load). Spans above are emitted at **info**, so the default `RUST_LOG=info` is enough.
 
+Subscriber setup lives in [`tracing_setup`](../../src/tracing_setup.rs): [`tracing-subscriber`](https://docs.rs/tracing-subscriber) (`RUST_LOG`), optional [`tracing-chrome`](https://docs.rs/tracing-chrome), [`tracing-log`](https://docs.rs/tracing-log) so legacy `log::` calls are merged into the same pipeline — see [tokio-rs/tracing](https://github.com/tokio-rs/tracing).
+
 **Reading totals:** the **Totals** row can be misleading if a parent span used to wrap the whole process (now avoided). For “where did one query spend time?”, use **average wall duration** of `dispatch_client_frame`, `sql.query`, `network.read_frame`, and `network.write_response`, and **zoom** the timeline to the short bars when `rustdb_load` was running — not the long idle gap while the server waited for Ctrl+C.
 
 On Windows, use [`scripts/run_server_chrome_trace.ps1`](../../scripts/run_server_chrome_trace.ps1).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,8 +11,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 use tracing::{info, warn};
-use tracing_subscriber::layer::SubscriberExt;
-use tracing_subscriber::util::SubscriberInitExt;
 
 /// RustDB - Relational database implementation in Rust
 #[derive(Parser)]
@@ -51,6 +49,11 @@ pub enum Commands {
         /// Write the dev TLS leaf certificate (DER) to this path for `rustdb_quic_client --cert`
         #[arg(long, value_name = "PATH")]
         cert_out: Option<PathBuf>,
+
+        /// Gracefully exit the server after this many seconds (useful for automated tracing so
+        /// `tracing-chrome` flushes the JSON file on shutdown).
+        #[arg(long, value_name = "SECS")]
+        exit_after_secs: Option<u64>,
     },
 
     /// Interface language management
@@ -145,7 +148,11 @@ impl Cli {
                 port,
                 host,
                 cert_out,
-            }) => self.run_server(host.clone(), *port, cert_out.clone()).await,
+                exit_after_secs,
+            }) => {
+                self.run_server(host.clone(), *port, cert_out.clone(), *exit_after_secs)
+                    .await
+            }
             Some(Commands::Language { action }) => self.handle_language_command(action).await,
             Some(Commands::Info) => self.show_info().await,
             Some(Commands::Create { name, data_dir }) => {
@@ -164,39 +171,15 @@ impl Cli {
         host_arg: Option<String>,
         port_arg: Option<u16>,
         cert_out: Option<PathBuf>,
+        exit_after_secs: Option<u64>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Logging + optional Chrome trace.
-        // Set `RUSTDB_TRACE_CHROME_PATH=/path/to/trace.json` to enable trace output.
-        let filter = tracing_subscriber::EnvFilter::try_from_default_env()
-            .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
-        let mut chrome_guard: Option<tracing_chrome::FlushGuard> = None;
-        if let Ok(path) = std::env::var("RUSTDB_TRACE_CHROME_PATH") {
-            if !path.trim().is_empty() {
-                let p = std::path::PathBuf::from(path);
-                if let Some(parent) = p.parent() {
-                    let _ = std::fs::create_dir_all(parent);
-                }
-                let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
-                    .file(p)
-                    .include_args(true)
-                    .build();
-                chrome_guard = Some(guard);
-                let _ = tracing_subscriber::registry()
-                    .with(filter)
-                    .with(chrome_layer)
-                    .with(tracing_subscriber::fmt::layer())
-                    .try_init();
-            } else {
-                let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
-            }
-        } else {
-            let _ = tracing_subscriber::fmt().with_env_filter(filter).try_init();
-        }
+        // `tracing` + `tracing-subscriber`: see [`crate::tracing_setup`].
+        let tracing_handle = crate::tracing_setup::init_server_tracing()?;
 
         // Do **not** hold a session-long `entered()` span here: it would dominate Chrome's
         // "Wall duration" totals (~time until Ctrl+C) and look like a 2-minute hotspot while
         // real work is only the short `network.*` / `dispatch_client_frame` / `sql.query` spans.
-        if chrome_guard.is_some() {
+        if tracing_handle.chrome_trace_enabled() {
             info!("Chrome trace: judge query cost from short spans (network.read_frame, dispatch_client_frame, sql.query); ignore any huge parent totals.");
         }
 
@@ -272,6 +255,14 @@ impl Cli {
             }
         };
 
+        let exit_after = async {
+            if let Some(secs) = exit_after_secs {
+                tokio::time::sleep(Duration::from_secs(secs.max(1))).await;
+            } else {
+                std::future::pending::<()>().await;
+            }
+        };
+
         tokio::select! {
             _ = tokio::signal::ctrl_c() => {
                 info!("shutdown requested");
@@ -280,6 +271,11 @@ impl Cli {
             }
             _ = term => {
                 info!("shutdown requested (SIGTERM)");
+                QuicServer::initiate_shutdown(&endpoint);
+                QuicServer::wait_idle(&endpoint).await;
+            }
+            _ = exit_after => {
+                info!(exit_after_secs, "shutdown requested (exit-after-secs)");
                 QuicServer::initiate_shutdown(&endpoint);
                 QuicServer::wait_idle(&endpoint).await;
             }
@@ -292,7 +288,7 @@ impl Cli {
         }
 
         // Ensure Chrome trace is flushed on shutdown.
-        drop(chrome_guard);
+        drop(tracing_handle);
         Ok(())
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -447,6 +447,7 @@ mod tests {
             port,
             host,
             cert_out,
+            ..
         }) = cli.command
         {
             assert_eq!(port, Some(9000));
@@ -464,6 +465,7 @@ mod tests {
             port,
             host,
             cert_out,
+            ..
         }) = cli.command
         {
             assert!(port.is_none());

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -447,12 +447,13 @@ mod tests {
             port,
             host,
             cert_out,
-            ..
+            exit_after_secs,
         }) = cli.command
         {
             assert_eq!(port, Some(9000));
             assert_eq!(host, Some("127.0.0.1".to_string()));
             assert!(cert_out.is_none());
+            assert!(exit_after_secs.is_none());
         } else {
             panic!();
         }
@@ -465,12 +466,13 @@ mod tests {
             port,
             host,
             cert_out,
-            ..
+            exit_after_secs,
         }) = cli.command
         {
             assert!(port.is_none());
             assert!(host.is_none());
             assert!(cert_out.is_none());
+            assert!(exit_after_secs.is_none());
         } else {
             panic!();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub mod network;
 pub mod parser;
 pub mod planner;
 pub mod storage;
+pub mod tracing_setup;
 
 pub use network::SqlEngine;
 

--- a/src/network/query_stream.rs
+++ b/src/network/query_stream.rs
@@ -294,7 +294,7 @@ async fn write_error_response(
 #[instrument(
     level = "info",
     name = "network.query_stream",
-    skip(send, recv, engine, policy, metrics, _permit),
+    skip(send, recv, engine, policy, metrics, _permit)
 )]
 pub async fn handle_query_bidi_stream(
     mut send: SendStream,

--- a/src/network/query_stream.rs
+++ b/src/network/query_stream.rs
@@ -145,19 +145,19 @@ pub enum ReadFrameError {
     PayloadTooLarge(u32),
 }
 
-/// Sync dispatch: decode → engine → encode (used inside per-query timeout).
+/// Engine + encode path for an already-decoded [`ClientMessage`] (single decode on the QUIC hot path).
 ///
-/// Returned [`Arc`] is cheap to clone on wire-cache hits (shared frame bytes).
-///
-/// Span `dispatch_client_frame` is emitted at **info** so Chrome traces (`RUSTDB_TRACE_CHROME_PATH`)
-/// include engine time with default `RUST_LOG=info`.
-#[instrument(level = "info", skip(frame, engine, policy), fields(frame_len = frame.len()))]
-pub fn dispatch_client_frame(
-    frame: &[u8],
+/// Span name stays **`dispatch_client_frame`** so Chrome traces stay comparable to older runs.
+#[instrument(
+    level = "info",
+    name = "dispatch_client_frame",
+    skip(msg, engine, policy)
+)]
+pub fn dispatch_client_message(
+    msg: ClientMessage,
     engine: &dyn EngineHandle,
     policy: &StreamPolicy,
 ) -> Result<Arc<[u8]>, DispatchError> {
-    let msg = decode_client_frame_v1(frame)?;
     match msg {
         ClientMessage::Query(q) => {
             let span = info_span!(
@@ -219,6 +219,21 @@ pub fn dispatch_client_frame(
         )
         .into()),
     }
+}
+
+/// Sync dispatch: decode → engine → encode (used inside per-query timeout).
+///
+/// Returned [`Arc`] is cheap to clone on wire-cache hits (shared frame bytes).
+///
+/// For callers that decode separately (e.g. to attribute decode in `network.decode_frame`), use
+/// [`dispatch_client_message`] instead to avoid decoding twice.
+pub fn dispatch_client_frame(
+    frame: &[u8],
+    engine: &dyn EngineHandle,
+    policy: &StreamPolicy,
+) -> Result<Arc<[u8]>, DispatchError> {
+    let msg = decode_client_frame_v1(frame)?;
+    dispatch_client_message(msg, engine, policy)
 }
 
 fn likely_select_without_from(sql: &str) -> bool {
@@ -343,7 +358,7 @@ pub async fn handle_query_bidi_stream(
         let t0 = Instant::now();
         let result = tokio::time::timeout(policy.query_timeout, async {
             match decoded {
-                Ok(_) => dispatch_client_frame(&frame_buf, engine.as_ref(), policy.as_ref()),
+                Ok(msg) => dispatch_client_message(msg, engine.as_ref(), policy.as_ref()),
                 Err(e) => Err(e.into()),
             }
         })

--- a/src/network/query_stream.rs
+++ b/src/network/query_stream.rs
@@ -288,6 +288,14 @@ async fn write_error_response(
 }
 
 /// One bidirectional stream: read one request frame, run engine (with timeout), write one response.
+///
+/// Parent span **`network.query_stream`** groups per-stream work in `tracing` / Chrome traces;
+/// nested spans include `network.read_frame`, `dispatch_client_frame`, `sql.query`, `network.write_response`.
+#[instrument(
+    level = "info",
+    name = "network.query_stream",
+    skip(send, recv, engine, policy, metrics, _permit),
+)]
 pub async fn handle_query_bidi_stream(
     mut send: SendStream,
     mut recv: RecvStream,
@@ -306,6 +314,7 @@ pub async fn handle_query_bidi_stream(
     let mut frame_buf = Vec::new();
 
     for _ in 0..MAX_FRAMES_PER_STREAM {
+        // Includes socket/stream wait time (dominant under load). Helps distinguish pure compute spans below.
         let read_res = read_application_frame_into(&mut recv, max_frame, &mut frame_buf)
             .instrument(tracing::info_span!("network.read_frame"))
             .await;
@@ -326,9 +335,17 @@ pub async fn handle_query_bidi_stream(
             }
         }
 
+        // Decode cost (no network wait) so we can compare with `network.read_frame`.
+        // Kept outside `dispatch_client_frame` for time-slicing in Chrome traces.
+        let decode_span = info_span!("network.decode_frame", frame_len = frame_buf.len());
+        let decoded = decode_span.in_scope(|| decode_client_frame_v1(&frame_buf));
+
         let t0 = Instant::now();
         let result = tokio::time::timeout(policy.query_timeout, async {
-            dispatch_client_frame(&frame_buf, engine.as_ref(), policy.as_ref())
+            match decoded {
+                Ok(_) => dispatch_client_frame(&frame_buf, engine.as_ref(), policy.as_ref()),
+                Err(e) => Err(e.into()),
+            }
         })
         .await;
 
@@ -354,8 +371,9 @@ pub async fn handle_query_bidi_stream(
         match result {
             Ok(bytes) => {
                 let out_len = bytes.len() as u64;
+                // Includes QUIC send backpressure/wait; encode cost is tracked inside dispatch (TLS buffer).
                 if let Err(e) = async { send.write_all(bytes.as_ref()).await }
-                    .instrument(tracing::info_span!("network.write_response"))
+                    .instrument(tracing::info_span!("network.write_response", out_len))
                     .await
                 {
                     warn!(error = %e, "write response failed");
@@ -399,7 +417,12 @@ pub async fn run_connection_streams(
     let remote = connection.remote_address();
 
     loop {
-        let incoming = match connection.accept_bi().await {
+        // Includes waiting for the peer to open a stream.
+        let incoming = match connection
+            .accept_bi()
+            .instrument(tracing::info_span!("network.accept_bi"))
+            .await
+        {
             Ok(s) => s,
             Err(quinn::ConnectionError::ApplicationClosed { .. }) => {
                 info!(%remote, "connection closed (application)");
@@ -416,7 +439,16 @@ pub async fn run_connection_streams(
         };
 
         let (mut send, recv) = incoming;
-        let permit = match sem.clone().acquire_owned().await {
+        // Separates "scheduler/queueing due to max streams" from network I/O.
+        let permit = match sem
+            .clone()
+            .acquire_owned()
+            .instrument(tracing::info_span!(
+                "network.acquire_stream_permit",
+                max = max
+            ))
+            .await
+        {
             Ok(p) => p,
             Err(_) => break,
         };

--- a/src/tracing_setup.rs
+++ b/src/tracing_setup.rs
@@ -1,0 +1,69 @@
+//! Global `tracing` subscriber for the RustDB server ([tokio-rs/tracing](https://github.com/tokio-rs/tracing)).
+//!
+//! Configures [`tracing-subscriber`](https://docs.rs/tracing-subscriber) with:
+//! - [`EnvFilter`](tracing_subscriber::EnvFilter) from **`RUST_LOG`** (default `info`);
+//! - optional [`tracing-chrome`](https://docs.rs/tracing-chrome) JSON when **`RUSTDB_TRACE_CHROME_PATH`** is set
+//!   (open in Chrome’s **chrome://tracing**);
+//! - [`fmt`](tracing_subscriber::fmt) for human-readable stderr logs.
+//!
+//! After the subscriber is installed, [`tracing-log`](https://docs.rs/tracing-log) bridges the legacy
+//! [`log`](https://docs.rs/log) crate so `log::info!` etc. are recorded by the same pipeline.
+
+use std::path::PathBuf;
+
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+
+/// Holds resources that must stay alive for the duration of the process (e.g. Chrome trace flush on drop).
+pub struct ServerTracing {
+    chrome_flush_guard: Option<tracing_chrome::FlushGuard>,
+}
+
+impl ServerTracing {
+    /// `true` when **`RUSTDB_TRACE_CHROME_PATH`** was set and a Chrome JSON trace is being written.
+    pub fn chrome_trace_enabled(&self) -> bool {
+        self.chrome_flush_guard.is_some()
+    }
+}
+
+/// Install the global default subscriber. Call **once** at process startup (e.g. `rustdb server`).
+pub fn init_server_tracing() -> Result<ServerTracing, String> {
+    let filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+
+    let chrome_path = std::env::var("RUSTDB_TRACE_CHROME_PATH").ok();
+    let mut chrome_guard = None;
+
+    match chrome_path {
+        Some(ref p) if !p.trim().is_empty() => {
+            let pb = PathBuf::from(p);
+            if let Some(parent) = pb.parent() {
+                std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+            }
+            let (chrome_layer, guard) = tracing_chrome::ChromeLayerBuilder::new()
+                .file(pb)
+                .include_args(true)
+                .build();
+            chrome_guard = Some(guard);
+            tracing_subscriber::registry()
+                .with(filter)
+                .with(chrome_layer)
+                .with(tracing_subscriber::fmt::layer())
+                .try_init()
+                .map_err(|e| e.to_string())?;
+        }
+        _ => {
+            tracing_subscriber::fmt()
+                .with_env_filter(filter)
+                .try_init()
+                .map_err(|e| e.to_string())?;
+        }
+    }
+
+    // Route `log::` records through tracing (storage WAL, etc.).
+    let _ = tracing_log::LogTracer::init();
+
+    Ok(ServerTracing {
+        chrome_flush_guard: chrome_guard,
+    })
+}

--- a/src/tracing_setup.rs
+++ b/src/tracing_setup.rs
@@ -4,7 +4,7 @@
 //! - [`EnvFilter`](tracing_subscriber::EnvFilter) from **`RUST_LOG`** (default `info`);
 //! - optional [`tracing-chrome`](https://docs.rs/tracing-chrome) JSON when **`RUSTDB_TRACE_CHROME_PATH`** is set
 //!   (open in Chrome’s **chrome://tracing**);
-//! - [`fmt`](tracing_subscriber::fmt) for human-readable stderr logs.
+//! - [`fmt`](mod@tracing_subscriber::fmt) for human-readable stderr logs.
 //!
 //! After the subscriber is installed, [`tracing-log`](https://docs.rs/tracing-log) bridges the legacy
 //! [`log`](https://docs.rs/log) crate so `log::info!` etc. are recorded by the same pipeline.


### PR DESCRIPTION
Centralize tracing-subscriber setup (fmt + optional tracing-chrome) and bridge legacy log:: calls via tracing-log. Add server --exit-after-secs for deterministic Chrome trace flush, and add spans to separate stream accept/permit wait, frame decode, and read/write backpressure in under-load traces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the QUIC query hot path and global tracing initialization; while behavior should be unchanged, mistakes could impact request handling performance or shutdown/trace flushing behavior under load.
> 
> **Overview**
> **Tracing is centralized and made more comprehensive.** Server startup now initializes tracing via new `tracing_setup::init_server_tracing()` (optional Chrome JSON output + `tracing-log` bridge) and drops the handle on shutdown to ensure trace flush.
> 
> **Server shutdown gains determinism for trace capture.** `rustdb server` adds `--exit-after-secs` to gracefully stop after a specified delay (in addition to Ctrl+C/SIGTERM), enabling automated Chrome trace collection.
> 
> **QUIC profiling spans are refined.** `query_stream` adds/adjusts spans to separate stream accept/permit wait, frame decode, and read/write backpressure, and splits dispatch into `dispatch_client_message` (no double-decode) while preserving the existing `dispatch_client_frame` span name for trace comparability.
> 
> **CI Docker tagging is made more robust.** The workflow switches to a short SHA-based tag (`sha-<short>`) to avoid invalid tags when branch names are missing in some PR/fork flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61ababc7a544651a2297c5c471eb9eaa1618a303. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->