### PR TITLE
Update CI/CD workflow to explicitly use nightly for Miri tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -186,10 +186,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libssl-dev pkg-config
 
+      # `rust-toolchain.toml` pins 1.90.0; Miri needs nightly — use +nightly explicitly.
       - name: Run Miri
         run: |
-          cargo miri setup
-          cargo miri test --lib
+          cargo +nightly miri setup
+          cargo +nightly miri test --lib
         env:
           MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-disable-isolation
 


### PR DESCRIPTION
- Modified the Miri setup and test commands in the CI/CD workflow to explicitly use the nightly toolchain, ensuring compatibility and proper functionality.
- This change addresses the requirement for nightly features in Miri, enhancing the reliability of library tests for undefined behavior.