### PR TITLE
Refactor CI/CD workflow by removing Miri checks and updating document…

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -161,40 +161,7 @@ jobs:
           cargo llvm-cov report --fail-under-lines 85 \
             --ignore-filename-regex "$COV_REGEX"
 
-  # Miri: undefined-behavior checks on library unit tests (integration tests in tests/ use async I/O).
-  miri:
-    name: Miri (lib tests)
-    runs-on: ubuntu-latest
-    needs: [test]
-    timeout-minutes: 45
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Rust nightly + Miri
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: miri
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-
-      - name: Install dependencies (Ubuntu)
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev pkg-config
-
-      # `rust-toolchain.toml` pins 1.90.0; Miri needs nightly — use +nightly explicitly.
-      - name: Run Miri
-        run: |
-          cargo +nightly miri setup
-          cargo +nightly miri test --lib
-        env:
-          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-disable-isolation
-
-  # After tests: code quality, MSRV, coverage, and Miri (in parallel), then release build.
+  # After tests: code quality and MSRV (in parallel), then release build.
   format:
     name: Format Check
     runs-on: ubuntu-latest
@@ -255,7 +222,7 @@ jobs:
   build:
     name: Build Release
     runs-on: ubuntu-latest
-    needs: [format, clippy, msrv, coverage, miri]
+    needs: [format, clippy, msrv, coverage]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -277,11 +244,11 @@ jobs:
           name: rustdb-linux-x64
           path: target/release/rustdb
 
-  # Alongside the release build: same prerequisites (format, clippy, msrv, miri), in parallel.
+  # Alongside the release build: same prerequisites (format, clippy, msrv), in parallel.
   docker:
     name: Docker Build
     runs-on: ubuntu-latest
-    needs: [format, clippy, msrv, coverage, miri]
+    needs: [format, clippy, msrv, coverage]
     outputs:
       image: ${{ steps.set_image.outputs.image }}
     permissions:
@@ -734,7 +701,7 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
-    needs: [format, clippy, msrv, coverage, miri]
+    needs: [format, clippy, msrv, coverage]
     permissions:
       contents: write
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -134,36 +134,3 @@ jobs:
           cd "${{ github.workspace }}"
           cargo semver-checks check-release
         continue-on-error: true
-
-  # Memory safety checks
-  memory_safety:
-    name: Memory Safety Check
-    # Temporarily disabled (too slow/flaky). Re-enable by removing this `if`.
-    if: ${{ false }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: miri
-
-      - name: Setup cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
-
-      # Library unit tests only: integration tests in `tests/` use async I/O and are covered
-      # by `cargo test` in CI. Async `#[tokio::test]` cases in `src/` are skipped under Miri
-      # via `#[cfg_attr(miri, ignore)]`.
-      - name: Run Miri
-        run: |
-          cargo +nightly miri setup
-          cargo +nightly miri test --lib
-        env:
-          # Strict provenance: keep unsafe pointer discipline checks.
-          # Disable isolation: std::env::temp_dir, SystemTime::now, file I/O in unit tests
-          # (tempfile, config roundtrip) are otherwise unsupported under Miri's default host isolation.
-          MIRIFLAGS: -Zmiri-strict-provenance -Zmiri-disable-isolation

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,6 @@ Workflow: [`.github/workflows/ci-cd.yml`](.github/workflows/ci-cd.yml). Pushes a
 |------------------------------|---------|
 | **Test Suite** (`test`) | **Ubuntu** matrix: `stable` and `beta`. `cargo test`, integration tests, doc tests. On **stable** additionally: `cargo audit`, **cargo-deny** (licenses, duplicates, advisories). |
 | **Coverage** | `cargo llvm-cov`, upload to **Codecov**, **≥85%** line threshold with `ignore-filename-regex` for heavy/internal modules. |
-| **Miri (lib tests)** | **Nightly** toolchain: `cargo miri setup` and `cargo miri test --lib` with strict provenance (integration tests in `tests/` are not run; async cases in `src/` are skipped via `#[cfg_attr(miri, ignore)]`). Depends on `test`. Gates **build**, **docker**, and **docs**. |
 | **Format Check** | `cargo fmt --all -- --check`. Depends on successful `test`. |
 | **Clippy Check** | `cargo clippy --all-targets -- -D warnings`. Depends on `test`. |
 | **MSRV** | `cargo check` on **Rust 1.90.0** (minimum supported Rust). Depends on `test`. |

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ A more detailed component diagram (PlantUML) lives in [`architecture.puml`](arch
 | **Parallelism** | rayon, crossbeam, dashmap, parking_lot |
 | **Storage helpers** | memmap2, lz4_flex, twox-hash, uuid |
 | **Config** | TOML |
-| **CI** | GitHub Actions: tests, Miri (lib, nightly), clippy, fmt, MSRV, coverage (llvm-cov + Codecov), cargo-deny, cargo-audit, Docker build & smoke, benchmarks, optional trace + flamegraph (see [CONTRIBUTING.md](CONTRIBUTING.md)) |
+| **CI** | GitHub Actions: tests, clippy, fmt, MSRV, coverage (llvm-cov + Codecov), cargo-deny, cargo-audit, Docker build & smoke, benchmarks, optional trace + flamegraph (see [CONTRIBUTING.md](CONTRIBUTING.md)) |
 | **Containers** | Multi-stage Dockerfile; images pushed to **GHCR** |
 
 **Supported platform for “production-style” experiments:** **Linux**. Other OSes are not a supported deployment target.


### PR DESCRIPTION
…ation

- Removed Miri checks from the CI/CD workflow due to performance concerns, streamlining the testing process.
- Updated `CONTRIBUTING.md` and `README.md` to reflect the removal of Miri from the CI pipeline, ensuring documentation is aligned with current practices.
- Enhanced clarity in CI job dependencies by eliminating unnecessary Miri requirements, improving overall workflow efficiency.