### PR TITLE
perf(tpcc): run-22 PR1 — commit flush v2 + engine accounting

### DIFF
--- a/scripts/summarize_sql_phase_log.py
+++ b/scripts/summarize_sql_phase_log.py
@@ -144,8 +144,17 @@ def extract_execute_tpcc_commit_us(line: str) -> tuple[int, int, dict[str, int]]
     for name in (
         "commit_transaction_wall_us",
         "commit_gap_us",
+        "commit_engine_gap_us",
+        "commit_wal_us",
+        "commit_index_batch_us",
+        "commit_log_append_us",
+        "commit_flush_us",
         "commit_pm_lock_wait_us",
+        "commit_pm_lock_scan_us",
+        "commit_pm_lock_flush_us",
         "commit_heap_fsync_us",
+        "flush_pm_count",
+        "dirty_pages_flushed",
     ):
         m_extra = re.search(rf"{name}=(\d+)", line)
         if m_extra:
@@ -189,12 +198,18 @@ COMMIT_SUB_PHASES = (
     "commit_log_append_us",
     "commit_log_commit_wait_us",
     "commit_table_map_lock_us",
+    "commit_pm_lock_scan_us",
+    "commit_pm_lock_flush_us",
     "commit_pm_lock_wait_us",
     "commit_heap_fsync_us",
+    "flush_pm_count",
+    "dirty_pages_flushed",
 )
 
 COMMIT_KIND_REPORT_PHASES = (
     "commit_table_map_lock_us",
+    "commit_pm_lock_scan_us",
+    "commit_pm_lock_flush_us",
     "commit_pm_lock_wait_us",
     "commit_wal_us",
     "commit_flush_us",
@@ -370,8 +385,13 @@ def main() -> int:
             execute_tpcc_commit_us.append(float(commit_us))
             if kind >= 0:
                 execute_tpcc_commit_by_kind[kind].append(float(commit_us))
-                if "commit_gap_us" in extra:
-                    execute_tpcc_commit_gap_by_kind[kind].append(float(extra["commit_gap_us"]))
+                gap_key = (
+                    "commit_engine_gap_us"
+                    if "commit_engine_gap_us" in extra
+                    else "commit_gap_us"
+                )
+                if gap_key in extra:
+                    execute_tpcc_commit_gap_by_kind[kind].append(float(extra[gap_key]))
             phase_lines += 1
         sc = extract_sql_commit_by_kind(line)
         if sc is not None:
@@ -590,7 +610,7 @@ def main() -> int:
             f"phases_sum={phase_sum_p50 / 1000:.3f}ms "
             f"pre_commit={pre_p50 / 1000:.3f}ms "
             f"commit_us={commit_p50 / 1000:.3f}ms "
-            f"commit_gap_us={commit_gap_p50 / 1000:.3f}ms "
+            f"commit_engine_gap_us={commit_gap_p50 / 1000:.3f}ms "
             f"unaccounted_gap={gap / 1000:.3f}ms"
         )
     if scan_us:

--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -153,6 +153,9 @@ pub struct SessionContext {
     pub(crate) tpcc_index_column_map_buf: HashMap<String, String>,
     /// Last `COMMIT` flush breakdown (native TPC-C gap accounting).
     pub(crate) last_commit_flush_phases: Option<crate::network::sql_engine_wal::CommitFlushPhaseUs>,
+    /// Last `COMMIT` engine sub-phases (WAL / index / log / flush wall).
+    pub(crate) last_commit_engine_phases:
+        Option<crate::network::sql_engine_wal::CommitEnginePhaseUs>,
 }
 
 impl std::fmt::Debug for SessionContext {
@@ -185,6 +188,7 @@ impl Default for SessionContext {
             txn_pm_cache: HashMap::new(),
             tpcc_index_column_map_buf: HashMap::new(),
             last_commit_flush_phases: None,
+            last_commit_engine_phases: None,
         }
     }
 }

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1209,6 +1209,8 @@ fn begin_transaction(
 ) -> Result<EngineOutput, EngineError> {
     ctx.txn_pm_cache.clear();
     ctx.tpcc_index_column_map_buf.clear();
+    ctx.last_commit_flush_phases = None;
+    ctx.last_commit_engine_phases = None;
     if ctx.transaction.is_some() {
         return Err(EngineError::new(
             engine_error_code::ALREADY_IN_TRANSACTION,
@@ -1283,9 +1285,24 @@ fn commit_transaction(
     span.record("flush_tables_count", flush_tables_count);
     let flush_clock = Instant::now();
     let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
+        let (dirty_pms, _dirty_pages, pm_lock_scan_us) =
+            crate::network::sql_engine_wal::collect_dirty_txn_page_managers(&ctx.txn_pm_cache);
+        if dirty_pms.is_empty() {
+            (
+                0,
+                crate::network::sql_engine_wal::CommitFlushPhaseUs {
+                    pm_lock_scan_us,
+                    pm_lock_wait_us: pm_lock_scan_us,
+                    ..Default::default()
+                },
+            )
+        } else {
+            crate::network::sql_engine_wal::flush_dirty_page_managers_sorted(
+                dirty_pms,
+                pm_lock_scan_us,
+            )
+            .map_err(map_db_err)?
+        }
     } else if touched.is_empty() {
         (
             0,
@@ -1318,8 +1335,12 @@ fn commit_transaction(
             commit_log_append_us,
             commit_log_commit_wait_us,
             commit_table_map_lock_us = flush_phases.table_map_lock_us,
+            commit_pm_lock_scan_us = flush_phases.pm_lock_scan_us,
+            commit_pm_lock_flush_us = flush_phases.pm_lock_flush_us,
             commit_pm_lock_wait_us = flush_phases.pm_lock_wait_us,
             commit_heap_fsync_us = flush_phases.heap_fsync_us,
+            flush_pm_count = flush_phases.flush_pm_count,
+            dirty_pages_flushed = flush_phases.dirty_pages_flushed,
             flush_tables_count,
             touched_table_count,
             pending_index_count,
@@ -1328,6 +1349,12 @@ fn commit_transaction(
         );
     }
     ctx.last_commit_flush_phases = Some(flush_phases);
+    ctx.last_commit_engine_phases = Some(crate::network::sql_engine_wal::CommitEnginePhaseUs {
+        commit_wal_us,
+        commit_index_batch_us,
+        commit_log_append_us,
+        commit_flush_us,
+    });
     ctx.txn_pm_cache.clear();
     drop(tx);
     Ok(EngineOutput::ExecutionOk { rows_affected: 0 })
@@ -1374,12 +1401,17 @@ fn rollback_transaction(
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
     let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
-            .iter()
-            .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
-            .collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map(|(n, _)| n)
+        let (dirty_pms, _, pm_lock_scan_us) =
+            crate::network::sql_engine_wal::collect_dirty_txn_page_managers(&ctx.txn_pm_cache);
+        if dirty_pms.is_empty() {
+            Ok(0)
+        } else {
+            crate::network::sql_engine_wal::flush_dirty_page_managers_sorted(
+                dirty_pms,
+                pm_lock_scan_us,
+            )
+            .map(|(n, _)| n)
+        }
     } else {
         crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &flush_tables)
             .map(|(n, _)| n)
@@ -3115,10 +3147,11 @@ pub(crate) fn tpcc_run_in_transaction(
 ) -> Result<EngineOutput, EngineError> {
     ctx.tpcc_kind = Some(kind);
     ctx.tpcc_dml_done_at = None;
-    ctx.last_commit_flush_phases = None;
     ctx.tpcc_row_bytes_buf.clear();
     ctx.txn_pm_cache.clear();
     ctx.tpcc_index_column_map_buf.clear();
+    ctx.last_commit_flush_phases = None;
+    ctx.last_commit_engine_phases = None;
     begin_transaction(state, ctx)?;
     match f(state, ctx) {
         Ok(rows) => {
@@ -3131,18 +3164,45 @@ pub(crate) fn tpcc_run_in_transaction(
                 commit_transaction(state, ctx)?;
                 let commit_transaction_wall_us = t0.elapsed().as_micros() as u64;
                 let flush_phases = ctx.last_commit_flush_phases.take();
-                if let Some(p) = flush_phases {
-                    let accounted_flush_us = p.pm_lock_wait_us.saturating_add(p.heap_fsync_us);
+                let engine_phases = ctx.last_commit_engine_phases.take();
+                if let Some(eng) = engine_phases {
+                    let accounted_us = eng
+                        .commit_wal_us
+                        .saturating_add(eng.commit_index_batch_us)
+                        .saturating_add(eng.commit_log_append_us)
+                        .saturating_add(eng.commit_flush_us);
+                    let commit_engine_gap_us =
+                        commit_transaction_wall_us.saturating_sub(accounted_us);
+                    let (
+                        flush_pm_count,
+                        dirty_pages_flushed,
+                        commit_pm_lock_scan_us,
+                        commit_pm_lock_flush_us,
+                    ) = flush_phases
+                        .map(|p| {
+                            (
+                                p.flush_pm_count,
+                                p.dirty_pages_flushed,
+                                p.pm_lock_scan_us,
+                                p.pm_lock_flush_us,
+                            )
+                        })
+                        .unwrap_or((0, 0, 0, 0));
                     info!(
                         target: "rustdb::sql_phases",
                         tpcc_kind = kind,
                         commit_us = commit_transaction_wall_us,
                         commit_transaction_wall_us,
                         pre_commit_us,
-                        commit_pm_lock_wait_us = p.pm_lock_wait_us,
-                        commit_heap_fsync_us = p.heap_fsync_us,
-                        commit_gap_us = commit_transaction_wall_us
-                            .saturating_sub(accounted_flush_us),
+                        commit_wal_us = eng.commit_wal_us,
+                        commit_index_batch_us = eng.commit_index_batch_us,
+                        commit_log_append_us = eng.commit_log_append_us,
+                        commit_flush_us = eng.commit_flush_us,
+                        commit_engine_gap_us,
+                        flush_pm_count,
+                        dirty_pages_flushed,
+                        commit_pm_lock_scan_us,
+                        commit_pm_lock_flush_us,
                         "sql.execute_tpcc.commit"
                     );
                 } else {
@@ -3152,7 +3212,6 @@ pub(crate) fn tpcc_run_in_transaction(
                         commit_us = commit_transaction_wall_us,
                         commit_transaction_wall_us,
                         pre_commit_us,
-                        commit_gap_us = commit_transaction_wall_us,
                         "sql.execute_tpcc.commit"
                     );
                 }

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -315,8 +315,95 @@ pub(crate) fn bench_defer_heap_fsync_enabled() -> bool {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct CommitFlushPhaseUs {
     pub table_map_lock_us: u64,
+    /// PM mutex wait while scanning `dirty_page_count` before flush.
+    pub pm_lock_scan_us: u64,
+    /// PM mutex wait inside `flush_dirty_pages_no_sync` / coalesced fsync.
+    pub pm_lock_flush_us: u64,
+    /// `pm_lock_scan_us` + `pm_lock_flush_us` (single field for dashboards).
     pub pm_lock_wait_us: u64,
     pub heap_fsync_us: u64,
+    pub flush_pm_count: u32,
+    pub dirty_pages_flushed: usize,
+}
+
+/// WAL / index / log-append breakdown for the last `COMMIT` (native TPC-C accounting).
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct CommitEnginePhaseUs {
+    pub commit_wal_us: u64,
+    pub commit_index_batch_us: u64,
+    pub commit_log_append_us: u64,
+    pub commit_flush_us: u64,
+}
+
+/// Collects page managers with dirty heap pages from a txn cache (one lock pass per PM).
+pub(crate) fn collect_dirty_txn_page_managers(
+    cache: &std::collections::HashMap<String, Arc<Mutex<PageManager>>>,
+) -> (Vec<Arc<Mutex<PageManager>>>, usize, u64) {
+    let mut dirty_pms = Vec::new();
+    let mut dirty_pages = 0usize;
+    let mut pm_lock_scan_us = 0u64;
+    for pm in cache.values() {
+        let lock_t0 = Instant::now();
+        let count = pm.lock().map(|g| g.dirty_page_count()).unwrap_or(0);
+        pm_lock_scan_us += lock_t0.elapsed().as_micros() as u64;
+        if count > 0 {
+            dirty_pages += count;
+            dirty_pms.push(pm.clone());
+        }
+    }
+    dirty_pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
+    (dirty_pms, dirty_pages, pm_lock_scan_us)
+}
+
+fn collect_dirty_page_managers(
+    pms: &[Arc<Mutex<PageManager>>],
+) -> (Vec<Arc<Mutex<PageManager>>>, usize, u64) {
+    let mut dirty_pms = Vec::new();
+    let mut dirty_pages = 0usize;
+    let mut pm_lock_scan_us = 0u64;
+    for pm in pms {
+        let lock_t0 = Instant::now();
+        let count = pm.lock().map(|g| g.dirty_page_count()).unwrap_or(0);
+        pm_lock_scan_us += lock_t0.elapsed().as_micros() as u64;
+        if count > 0 {
+            dirty_pages += count;
+            dirty_pms.push(pm.clone());
+        }
+    }
+    dirty_pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
+    (dirty_pms, dirty_pages, pm_lock_scan_us)
+}
+
+/// Flushes pre-filtered dirty PMs (parallel when `len > 1`; keeps main coalesced behavior).
+pub(crate) fn flush_dirty_page_managers_sorted(
+    dirty_pms: Vec<Arc<Mutex<PageManager>>>,
+    pm_lock_scan_us: u64,
+) -> DbResult<(usize, CommitFlushPhaseUs)> {
+    let flush_pm_count = dirty_pms.len() as u32;
+    if dirty_pms.is_empty() {
+        return Ok((
+            0,
+            CommitFlushPhaseUs {
+                pm_lock_scan_us,
+                pm_lock_wait_us: pm_lock_scan_us,
+                ..Default::default()
+            },
+        ));
+    }
+    let (flushed_pages, pm_lock_flush_us, heap_fsync_us) =
+        coalesced_flush_page_managers(dirty_pms)?;
+    Ok((
+        flushed_pages,
+        CommitFlushPhaseUs {
+            table_map_lock_us: 0,
+            pm_lock_scan_us,
+            pm_lock_flush_us,
+            pm_lock_wait_us: pm_lock_scan_us.saturating_add(pm_lock_flush_us),
+            heap_fsync_us,
+            flush_pm_count,
+            dirty_pages_flushed: flushed_pages,
+        },
+    ))
 }
 
 fn flush_pm_writes_only(pm: &Arc<Mutex<PageManager>>) -> DbResult<(usize, Option<u32>, u64)> {
@@ -412,28 +499,23 @@ pub(crate) fn flush_page_managers_for_tables(
         .map_err(|_| DbError::database("table pm map lock poisoned"))?;
     let table_map_lock_us = map_t0.elapsed().as_micros() as u64;
     let mut pms: Vec<Arc<Mutex<PageManager>>> = Vec::with_capacity(sorted.len());
-    let mut pm_lock_wait_us = 0u64;
+    let mut pm_lock_scan_us = 0u64;
     for name in &sorted {
         let Some(pm) = map.get(name) else {
             continue;
         };
         let lock_t0 = Instant::now();
         let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
-        pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
+        pm_lock_scan_us += lock_t0.elapsed().as_micros() as u64;
         if dirty {
             pms.push(pm.clone());
         }
     }
     drop(map);
-    let (flushed, flush_pm_wait, heap_fsync_us) = coalesced_flush_page_managers(pms)?;
-    Ok((
-        flushed,
-        CommitFlushPhaseUs {
-            table_map_lock_us,
-            pm_lock_wait_us: pm_lock_wait_us.saturating_add(flush_pm_wait),
-            heap_fsync_us,
-        },
-    ))
+    pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
+    let (flushed, mut phases) = flush_dirty_page_managers_sorted(pms, pm_lock_scan_us)?;
+    phases.table_map_lock_us = table_map_lock_us;
+    Ok((flushed, phases))
 }
 
 /// Flushes dirty pages for the given page managers without acquiring `table_page_managers`.
@@ -445,26 +527,8 @@ pub(crate) fn flush_page_managers_cached(
     if pms.is_empty() {
         return Ok((0, CommitFlushPhaseUs::default()));
     }
-    let mut dirty_pms: Vec<Arc<Mutex<PageManager>>> = Vec::new();
-    let mut pm_lock_wait_us = 0u64;
-    for pm in pms {
-        let lock_t0 = Instant::now();
-        let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
-        pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
-        if dirty {
-            dirty_pms.push(pm.clone());
-        }
-    }
-    dirty_pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-    let (flushed, flush_pm_wait, heap_fsync_us) = coalesced_flush_page_managers(dirty_pms)?;
-    Ok((
-        flushed,
-        CommitFlushPhaseUs {
-            table_map_lock_us: 0,
-            pm_lock_wait_us: pm_lock_wait_us.saturating_add(flush_pm_wait),
-            heap_fsync_us,
-        },
-    ))
+    let (dirty_pms, _dirty_pages, pm_lock_scan_us) = collect_dirty_page_managers(pms);
+    flush_dirty_page_managers_sorted(dirty_pms, pm_lock_scan_us)
 }
 
 pub(crate) fn flush_all_page_managers(


### PR DESCRIPTION
## Summary
- Flush only dirty page managers from `txn_pm_cache` (avoids PR #54 regression from flushing all cached PMs).
- Split `commit_pm_lock_scan_us` / `commit_pm_lock_flush_us`; log `flush_pm_count` and `dirty_pages_flushed`.
- Fix native TPC-C `commit_engine_gap_us` accounting (WAL + index + log + flush vs wall).

## Test plan
- [ ] CI Format + unit tests
- [ ] `bench_tpcc_throughput` on this branch (tpcc* prefix)
- [ ] Compare vs run-21 main: TPS ≥58%, new_order `commit_us` p50 <70ms, `commit_flush` p50 <55ms

Made with [Cursor](https://cursor.com)