### PR TITLE
perf(tpcc): run-22 PR2 — DML tail buffer reuse

### DIFF
--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -684,7 +684,9 @@ pub(crate) fn insert_row_tuple_tpcc_deferred(
         });
     }
     record_touched_table(ctx, table);
-    ctx.tpcc_row_bytes_buf = tuple.to_bytes().map_err(map_db_err)?;
+    let row_bytes = tuple.to_bytes().map_err(map_db_err)?;
+    ctx.tpcc_row_bytes_buf.clear();
+    ctx.tpcc_row_bytes_buf.extend_from_slice(&row_bytes);
     let pm_for_table = table_page_manager_cached(state, ctx, table)?;
     let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
     let ins = pm.insert(&ctx.tpcc_row_bytes_buf).map_err(map_db_err)?;


### PR DESCRIPTION
## Summary
- Reuse `tpcc_row_bytes_buf` on deferred TPC-C inserts (`clear` + `extend_from_slice`) instead of reallocating via assignment each row.

## Test plan
- [ ] CI unit tests
- [ ] `bench_tpcc_throughput` (branch name triggers bench job)
- [ ] Expect improvement on `insert_order_line_us` / `insert_oorder_us` in phase log

Made with [Cursor](https://cursor.com)