### PR TITLE
chore(tpcc): run-22 PR3 — flush observability + CI stretch targets

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -458,8 +458,9 @@ jobs:
   # Final throughput benchmark: TPC-C-ish (transactional write-heavy mix) for RustDB over QUIC.
   # Runs on: main push, workflow_dispatch, and pull_request when head branch is tpcc* (perf PRs).
   # Other PRs: use Actions → workflow_dispatch on the PR branch, or merge to main.
-  # Run 20 policy: keep full-mix soft floor at 58% until two consecutive CI runs reach ≥56%;
-  # do not raise the floor early. order_status micro stays at 70%; new_order latency warnings unchanged.
+  # Run 20/22 policy: keep full-mix soft floor at 58% until two consecutive CI runs reach ≥56%;
+  # do not raise the floor early. order_status micro stays at 70%.
+  # Run 22 stretch (informational): new_order commit_us p50 <70ms, commit_flush_us p50 <55ms on two main runs.
   bench_tpcc_throughput:
     name: Benchmark TPC-C throughput (RustDB) + postgres_tpcc baseline (PostgreSQL)
     runs-on: ubuntu-latest
@@ -692,6 +693,17 @@ jobs:
             :
           else
             echo "::warning::new_order server commit_us p50 ${new_order_commit_p50}ms exceeds 50ms informational threshold"
+          fi
+          if python3 -c "exit(0 if float('${new_order_commit_p50}') <= 70.0 or float('${new_order_commit_p50}') <= 0 else 1)"; then
+            :
+          else
+            echo "::warning::new_order server commit_us p50 ${new_order_commit_p50}ms exceeds 70ms run-22 stretch target"
+          fi
+          new_order_commit_flush_p50="$(python3 -c "import re,statistics; from pathlib import Path; p=Path('tpcc-out/server_full.log'); us=[]; [us.append(int(m.group(1))) for line in (p.read_text(encoding='utf-8',errors='replace').splitlines() if p.is_file() else []) if 'sql.commit' in line and 'tpcc_kind=0' in line for m in [re.search(r'commit_flush_us=(\d+)', line)] if m]; print(f'{statistics.median(us)/1000:.3f}' if us else '0')" 2>/dev/null || echo 0)"
+          if python3 -c "exit(0 if float('${new_order_commit_flush_p50}') <= 55.0 or float('${new_order_commit_flush_p50}') <= 0 else 1)"; then
+            :
+          else
+            echo "::warning::new_order sql.commit commit_flush_us p50 ${new_order_commit_flush_p50}ms exceeds 55ms run-22 stretch target"
           fi
           mix_os_p50="$(python3 -c "import csv,statistics; from pathlib import Path; p=Path('tpcc-out/tpcc_txn.log'); rows=[] if not p.is_file() else [r for r in csv.DictReader(p.read_text().splitlines()) if r.get('ok','').lower() in ('true','1') and r.get('kind')=='order_status']; us=[int(r['elapsed_us']) for r in rows if r.get('elapsed_us','').isdigit()]; print(f'{statistics.median(us)/1000:.3f}' if us else '0')" 2>/dev/null || echo 0)"
           micro_os_p50="$(python3 -c "import csv,statistics; from pathlib import Path; p=Path('tpcc-out/order_status_micro/tpcc_txn.log'); rows=[] if not p.is_file() else [r for r in csv.DictReader(p.read_text().splitlines()) if r.get('ok','').lower() in ('true','1') and r.get('kind')=='order_status']; us=[int(r['elapsed_us']) for r in rows if r.get('elapsed_us','').isdigit()]; print(f'{statistics.median(us)/1000:.3f}' if us else '0')" 2>/dev/null || echo 0)"

--- a/scripts/summarize_sql_phase_log.py
+++ b/scripts/summarize_sql_phase_log.py
@@ -168,6 +168,10 @@ def extract_sql_commit_by_kind(line: str) -> tuple[int, dict[str, int]] | None:
     m_flush = re.search(r"commit_flush_us=(\d+)", line)
     if m_flush:
         out["commit_flush_us"] = int(m_flush.group(1))
+    for name in COMMIT_FLUSH_METRICS:
+        m = re.search(rf"{name}=(\d+)", line)
+        if m:
+            out[name] = int(m.group(1))
     return kind, out if out else None
 
 
@@ -189,15 +193,26 @@ COMMIT_SUB_PHASES = (
     "commit_log_append_us",
     "commit_log_commit_wait_us",
     "commit_table_map_lock_us",
+    "commit_pm_lock_scan_us",
+    "commit_pm_lock_flush_us",
     "commit_pm_lock_wait_us",
     "commit_heap_fsync_us",
 )
 
+COMMIT_FLUSH_METRICS = (
+    "flush_pm_count",
+    "dirty_pages_flushed",
+)
+
 COMMIT_KIND_REPORT_PHASES = (
     "commit_table_map_lock_us",
+    "commit_pm_lock_scan_us",
+    "commit_pm_lock_flush_us",
     "commit_pm_lock_wait_us",
     "commit_wal_us",
     "commit_flush_us",
+    "flush_pm_count",
+    "dirty_pages_flushed",
 )
 
 TPCC_KIND_NAMES = {
@@ -573,6 +588,30 @@ def main() -> int:
                     parts.append(f"{phase}={quantile(xs, 0.5) / 1000:.3f}")
             if parts:
                 print(f"  {label}: {' '.join(parts)}")
+        new_order_commit = sql_commit_sub_by_kind.get(0, {})
+        if new_order_commit:
+            print("sql.commit flush metrics by tpcc_kind=new_order (p50/p95):")
+            for phase in (
+                "commit_flush_us",
+                "commit_pm_lock_scan_us",
+                "commit_pm_lock_flush_us",
+                "commit_pm_lock_wait_us",
+            ):
+                xs = new_order_commit.get(phase, [])
+                if xs:
+                    print(
+                        f"  {phase}: n={len(xs)} "
+                        f"p50={quantile(xs, 0.5) / 1000:.3f}ms "
+                        f"p95={quantile(xs, 0.95) / 1000:.3f}ms"
+                    )
+            for phase in ("flush_pm_count", "dirty_pages_flushed"):
+                xs = new_order_commit.get(phase, [])
+                if xs:
+                    print(
+                        f"  {phase}: n={len(xs)} "
+                        f"p50={quantile(xs, 0.5):.1f} "
+                        f"p95={quantile(xs, 0.95):.1f}"
+                    )
     if execute_tpcc_new_order_phases and execute_tpcc_by_kind.get(0):
         phase_sum_p50 = sum(
             quantile(execute_tpcc_new_order_phases.get(name, []), 0.5)


### PR DESCRIPTION
## Summary
- Re-land PR #54 observability in `summarize_sql_phase_log.py` (flush scan/flush split, `flush_pm_count`, new_order flush report) **without** the sequential-flush regression.
- CI: informational run-22 stretch warnings (`commit_us` p50 >70ms, `commit_flush_us` p50 >55ms).

## Test plan
- [ ] CI passes
- [ ] After PR1 merges, rebase if `summarize_sql_phase_log.py` conflicts

Made with [Cursor](https://cursor.com)