### PR TITLE
perf(tpcc): run-23 PR2 — touched-only dirty PM flush

### DIFF
--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -148,7 +148,8 @@ pub struct SessionContext {
     /// Reused row serialization buffer for native TPC-C inserts in a transaction.
     pub(crate) tpcc_row_bytes_buf: Vec<u8>,
     /// Per-transaction page managers (avoids `table_page_managers` map lock on hot DML/COMMIT).
-    pub(crate) txn_pm_cache: HashMap<String, Arc<Mutex<PageManager>>>,
+    /// `file_id` is captured at cache insert so COMMIT flush can sort without a second PM lock.
+    pub(crate) txn_pm_cache: HashMap<String, (u32, Arc<Mutex<PageManager>>)>,
     /// Reused buffer for deferred index column maps (native TPC-C inserts).
     pub(crate) tpcc_index_column_map_buf: HashMap<String, String>,
     /// Last `COMMIT` flush breakdown (native TPC-C gap accounting).

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1284,10 +1284,28 @@ fn commit_transaction(
     let flush_tables_count = touched.len();
     span.record("flush_tables_count", flush_tables_count);
     let flush_clock = Instant::now();
-    let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
+    let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() && !touched.is_empty() {
+        let (dirty_pms, _dirty_pages, pm_lock_scan_us) =
+            crate::network::sql_engine_wal::collect_dirty_txn_page_managers(
+                &ctx.txn_pm_cache,
+                Some(&touched),
+            );
+        if dirty_pms.is_empty() {
+            (
+                0,
+                crate::network::sql_engine_wal::CommitFlushPhaseUs {
+                    pm_lock_scan_us,
+                    pm_lock_wait_us: pm_lock_scan_us,
+                    ..Default::default()
+                },
+            )
+        } else {
+            crate::network::sql_engine_wal::flush_dirty_page_managers_sorted(
+                dirty_pms,
+                pm_lock_scan_us,
+            )
+            .map_err(map_db_err)?
+        }
     } else if touched.is_empty() {
         (
             0,
@@ -1320,8 +1338,12 @@ fn commit_transaction(
             commit_log_append_us,
             commit_log_commit_wait_us,
             commit_table_map_lock_us = flush_phases.table_map_lock_us,
+            commit_pm_lock_scan_us = flush_phases.pm_lock_scan_us,
+            commit_pm_lock_flush_us = flush_phases.pm_lock_flush_us,
             commit_pm_lock_wait_us = flush_phases.pm_lock_wait_us,
             commit_heap_fsync_us = flush_phases.heap_fsync_us,
+            flush_pm_count = flush_phases.flush_pm_count,
+            dirty_pages_flushed = flush_phases.dirty_pages_flushed,
             flush_tables_count,
             touched_table_count,
             pending_index_count,
@@ -1376,12 +1398,20 @@ fn rollback_transaction(
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
     let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
-            .iter()
-            .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
-            .collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map(|(n, _)| n)
+        let (dirty_pms, _, pm_lock_scan_us) =
+            crate::network::sql_engine_wal::collect_dirty_txn_page_managers(
+                &ctx.txn_pm_cache,
+                Some(&flush_tables),
+            );
+        if dirty_pms.is_empty() {
+            Ok(0)
+        } else {
+            crate::network::sql_engine_wal::flush_dirty_page_managers_sorted(
+                dirty_pms,
+                pm_lock_scan_us,
+            )
+            .map(|(n, _)| n)
+        }
     } else {
         crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &flush_tables)
             .map(|(n, _)| n)
@@ -1540,11 +1570,13 @@ pub(crate) fn table_page_manager_cached(
     ctx: &mut SessionContext,
     table: &str,
 ) -> Result<Arc<Mutex<PageManager>>, EngineError> {
-    if let Some(pm) = ctx.txn_pm_cache.get(table) {
+    if let Some((_, pm)) = ctx.txn_pm_cache.get(table) {
         return Ok(pm.clone());
     }
     let pm = table_page_manager(state, table)?;
-    ctx.txn_pm_cache.insert(table.to_string(), pm.clone());
+    let file_id = pm.lock().map_err(|_| lock_poisoned_engine())?.file_id();
+    ctx.txn_pm_cache
+        .insert(table.to_string(), (file_id, pm.clone()));
     Ok(pm)
 }
 

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -315,8 +315,108 @@ pub(crate) fn bench_defer_heap_fsync_enabled() -> bool {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct CommitFlushPhaseUs {
     pub table_map_lock_us: u64,
+    /// PM mutex wait while scanning `dirty_page_count` before flush.
+    pub pm_lock_scan_us: u64,
+    /// PM mutex wait inside `flush_dirty_pages_no_sync` / coalesced fsync.
+    pub pm_lock_flush_us: u64,
+    /// `pm_lock_scan_us` + `pm_lock_flush_us` (single field for dashboards).
     pub pm_lock_wait_us: u64,
     pub heap_fsync_us: u64,
+    pub flush_pm_count: u32,
+    pub dirty_pages_flushed: usize,
+}
+
+/// Minimum dirty PM count before rayon parallel flush (avoids overhead on small txns).
+const COALESCED_FLUSH_PARALLEL_MIN: usize = 5;
+
+/// Collects dirty page managers from a txn cache, optionally limited to `tables`.
+pub(crate) fn collect_dirty_txn_page_managers(
+    cache: &std::collections::HashMap<String, (u32, Arc<Mutex<PageManager>>)>,
+    tables: Option<&std::collections::HashSet<String>>,
+) -> (Vec<Arc<Mutex<PageManager>>>, usize, u64) {
+    let mut dirty_entries: Vec<(u32, Arc<Mutex<PageManager>>)> = Vec::new();
+    let mut dirty_pages = 0usize;
+    let mut pm_lock_scan_us = 0u64;
+    let scan_tables: Vec<&String> = match tables {
+        Some(touched) => touched.iter().collect(),
+        None => cache.keys().collect(),
+    };
+    for table in scan_tables {
+        let Some((file_id, pm)) = cache.get(table) else {
+            continue;
+        };
+        let lock_t0 = Instant::now();
+        let count = pm.lock().map(|g| g.dirty_page_count()).unwrap_or(0);
+        pm_lock_scan_us += lock_t0.elapsed().as_micros() as u64;
+        if count > 0 {
+            dirty_pages += count;
+            dirty_entries.push((*file_id, pm.clone()));
+        }
+    }
+    dirty_entries.sort_by_key(|(file_id, _)| *file_id);
+    let dirty_pms = dirty_entries
+        .into_iter()
+        .map(|(_, pm)| pm)
+        .collect::<Vec<_>>();
+    (dirty_pms, dirty_pages, pm_lock_scan_us)
+}
+
+fn collect_dirty_page_managers(
+    pms: &[Arc<Mutex<PageManager>>],
+) -> (Vec<Arc<Mutex<PageManager>>>, usize, u64) {
+    let mut dirty_entries: Vec<(u32, Arc<Mutex<PageManager>>)> = Vec::new();
+    let mut dirty_pages = 0usize;
+    let mut pm_lock_scan_us = 0u64;
+    for pm in pms {
+        let lock_t0 = Instant::now();
+        let (count, file_id) = pm
+            .lock()
+            .map(|g| (g.dirty_page_count(), g.file_id()))
+            .unwrap_or((0, u32::MAX));
+        pm_lock_scan_us += lock_t0.elapsed().as_micros() as u64;
+        if count > 0 {
+            dirty_pages += count;
+            dirty_entries.push((file_id, pm.clone()));
+        }
+    }
+    dirty_entries.sort_by_key(|(file_id, _)| *file_id);
+    let dirty_pms = dirty_entries
+        .into_iter()
+        .map(|(_, pm)| pm)
+        .collect::<Vec<_>>();
+    (dirty_pms, dirty_pages, pm_lock_scan_us)
+}
+
+/// Flushes pre-filtered dirty PMs (parallel when `len >= COALESCED_FLUSH_PARALLEL_MIN`).
+pub(crate) fn flush_dirty_page_managers_sorted(
+    dirty_pms: Vec<Arc<Mutex<PageManager>>>,
+    pm_lock_scan_us: u64,
+) -> DbResult<(usize, CommitFlushPhaseUs)> {
+    let flush_pm_count = dirty_pms.len() as u32;
+    if dirty_pms.is_empty() {
+        return Ok((
+            0,
+            CommitFlushPhaseUs {
+                pm_lock_scan_us,
+                pm_lock_wait_us: pm_lock_scan_us,
+                ..Default::default()
+            },
+        ));
+    }
+    let (flushed_pages, pm_lock_flush_us, heap_fsync_us) =
+        coalesced_flush_page_managers(dirty_pms)?;
+    Ok((
+        flushed_pages,
+        CommitFlushPhaseUs {
+            table_map_lock_us: 0,
+            pm_lock_scan_us,
+            pm_lock_flush_us,
+            pm_lock_wait_us: pm_lock_scan_us.saturating_add(pm_lock_flush_us),
+            heap_fsync_us,
+            flush_pm_count,
+            dirty_pages_flushed: flushed_pages,
+        },
+    ))
 }
 
 fn flush_pm_writes_only(pm: &Arc<Mutex<PageManager>>) -> DbResult<(usize, Option<u32>, u64)> {
@@ -365,7 +465,7 @@ fn coalesced_flush_page_managers(pms: Vec<Arc<Mutex<PageManager>>>) -> DbResult<
     let mut sync_targets = Vec::new();
     let mut pm_lock_wait_us = 0u64;
 
-    if pms.len() <= 1 {
+    if pms.len() < COALESCED_FLUSH_PARALLEL_MIN {
         for pm in pms {
             let (n, file_id, wait) = flush_pm_writes_only(&pm)?;
             pm_lock_wait_us += wait;
@@ -411,29 +511,28 @@ pub(crate) fn flush_page_managers_for_tables(
         .lock()
         .map_err(|_| DbError::database("table pm map lock poisoned"))?;
     let table_map_lock_us = map_t0.elapsed().as_micros() as u64;
-    let mut pms: Vec<Arc<Mutex<PageManager>>> = Vec::with_capacity(sorted.len());
-    let mut pm_lock_wait_us = 0u64;
+    let mut dirty_entries: Vec<(u32, Arc<Mutex<PageManager>>)> = Vec::with_capacity(sorted.len());
+    let mut pm_lock_scan_us = 0u64;
     for name in &sorted {
         let Some(pm) = map.get(name) else {
             continue;
         };
         let lock_t0 = Instant::now();
-        let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
-        pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
+        let (dirty, file_id) = pm
+            .lock()
+            .map(|g| (g.dirty_page_count() > 0, g.file_id()))
+            .unwrap_or((false, u32::MAX));
+        pm_lock_scan_us += lock_t0.elapsed().as_micros() as u64;
         if dirty {
-            pms.push(pm.clone());
+            dirty_entries.push((file_id, pm.clone()));
         }
     }
     drop(map);
-    let (flushed, flush_pm_wait, heap_fsync_us) = coalesced_flush_page_managers(pms)?;
-    Ok((
-        flushed,
-        CommitFlushPhaseUs {
-            table_map_lock_us,
-            pm_lock_wait_us: pm_lock_wait_us.saturating_add(flush_pm_wait),
-            heap_fsync_us,
-        },
-    ))
+    dirty_entries.sort_by_key(|(file_id, _)| *file_id);
+    let pms: Vec<Arc<Mutex<PageManager>>> = dirty_entries.into_iter().map(|(_, pm)| pm).collect();
+    let (flushed, mut phases) = flush_dirty_page_managers_sorted(pms, pm_lock_scan_us)?;
+    phases.table_map_lock_us = table_map_lock_us;
+    Ok((flushed, phases))
 }
 
 /// Flushes dirty pages for the given page managers without acquiring `table_page_managers`.
@@ -445,26 +544,8 @@ pub(crate) fn flush_page_managers_cached(
     if pms.is_empty() {
         return Ok((0, CommitFlushPhaseUs::default()));
     }
-    let mut dirty_pms: Vec<Arc<Mutex<PageManager>>> = Vec::new();
-    let mut pm_lock_wait_us = 0u64;
-    for pm in pms {
-        let lock_t0 = Instant::now();
-        let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
-        pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
-        if dirty {
-            dirty_pms.push(pm.clone());
-        }
-    }
-    dirty_pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-    let (flushed, flush_pm_wait, heap_fsync_us) = coalesced_flush_page_managers(dirty_pms)?;
-    Ok((
-        flushed,
-        CommitFlushPhaseUs {
-            table_map_lock_us: 0,
-            pm_lock_wait_us: pm_lock_wait_us.saturating_add(flush_pm_wait),
-            heap_fsync_us,
-        },
-    ))
+    let (dirty_pms, _dirty_pages, pm_lock_scan_us) = collect_dirty_page_managers(pms);
+    flush_dirty_page_managers_sorted(dirty_pms, pm_lock_scan_us)
 }
 
 pub(crate) fn flush_all_page_managers(


### PR DESCRIPTION
## Summary
- **Phase 55**: On `COMMIT`, scan and flush dirty page managers only for tables in `touched_tables`, not the entire `txn_pm_cache`.
- Port dirty-only coalesced flush from PR #60 (parallel when ≥5 dirty PMs, `file_id` cached at insert) without the full-cache scan that regressed run-23 PR1 to ~56% vs PG.

## Context
PR #60 CI (run-23 PR1): **496.9 TPS / 880.1 PG = 56.5%** — regression vs main+PR58 (~60.8%). Root cause: `commit_pm_lock_scan_us` p50 **82ms** on `new_order` from scanning all cached PMs.

## Test plan
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test flush_page_managers explicit_transaction`
- [ ] CI Benchmark TPC-C throughput — expect ratio ≥60%, `commit_pm_lock_scan_us` p50 ≪15ms on new_order

## Do not merge
- PR #60 (superseded by this approach)