### PR TITLE
perf(tpcc): run-23 PR4 — single-pass serial commit flush

### DIFF
--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -148,7 +148,8 @@ pub struct SessionContext {
     /// Reused row serialization buffer for native TPC-C inserts in a transaction.
     pub(crate) tpcc_row_bytes_buf: Vec<u8>,
     /// Per-transaction page managers (avoids `table_page_managers` map lock on hot DML/COMMIT).
-    pub(crate) txn_pm_cache: HashMap<String, Arc<Mutex<PageManager>>>,
+    /// `file_id` is captured at cache insert so COMMIT can sort heaps without an extra PM lock.
+    pub(crate) txn_pm_cache: HashMap<String, (u32, Arc<Mutex<PageManager>>)>,
     /// Reused buffer for deferred index column maps (native TPC-C inserts).
     pub(crate) tpcc_index_column_map_buf: HashMap<String, String>,
     /// Last `COMMIT` flush breakdown (native TPC-C gap accounting).

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1285,9 +1285,12 @@ fn commit_transaction(
     span.record("flush_tables_count", flush_tables_count);
     let flush_clock = Instant::now();
     let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
+        let entries: Vec<(u32, Arc<Mutex<PageManager>>)> = ctx
+            .txn_pm_cache
+            .values()
+            .map(|(file_id, pm)| (*file_id, pm.clone()))
+            .collect();
+        crate::network::sql_engine_wal::flush_sorted_page_managers(entries).map_err(map_db_err)?
     } else if touched.is_empty() {
         (
             0,
@@ -1376,12 +1379,15 @@ fn rollback_transaction(
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
     let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
+        let entries: Vec<(u32, Arc<Mutex<PageManager>>)> = flush_tables
             .iter()
-            .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
+            .filter_map(|t| {
+                ctx.txn_pm_cache
+                    .get(t)
+                    .map(|(file_id, pm)| (*file_id, pm.clone()))
+            })
             .collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map(|(n, _)| n)
+        crate::network::sql_engine_wal::flush_sorted_page_managers(entries).map(|(n, _)| n)
     } else {
         crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &flush_tables)
             .map(|(n, _)| n)
@@ -1540,11 +1546,13 @@ pub(crate) fn table_page_manager_cached(
     ctx: &mut SessionContext,
     table: &str,
 ) -> Result<Arc<Mutex<PageManager>>, EngineError> {
-    if let Some(pm) = ctx.txn_pm_cache.get(table) {
+    if let Some((_, pm)) = ctx.txn_pm_cache.get(table) {
         return Ok(pm.clone());
     }
     let pm = table_page_manager(state, table)?;
-    ctx.txn_pm_cache.insert(table.to_string(), pm.clone());
+    let file_id = pm.lock().map_err(|_| lock_poisoned_engine())?.file_id();
+    ctx.txn_pm_cache
+        .insert(table.to_string(), (file_id, pm.clone()));
     Ok(pm)
 }
 

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -357,6 +357,27 @@ fn sync_heap_files_after_coalesced_flush(
     Ok(fsync_t0.elapsed().as_micros() as u64)
 }
 
+fn coalesced_flush_page_managers_serial(
+    pms: Vec<Arc<Mutex<PageManager>>>,
+) -> DbResult<(usize, u64, u64)> {
+    if pms.is_empty() {
+        return Ok((0, 0, 0));
+    }
+    let mut total = 0usize;
+    let mut sync_targets = Vec::new();
+    let mut pm_lock_wait_us = 0u64;
+    for pm in pms {
+        let (n, file_id, wait) = flush_pm_writes_only(&pm)?;
+        pm_lock_wait_us += wait;
+        total += n;
+        if let Some(file_id) = file_id {
+            sync_targets.push((file_id, pm));
+        }
+    }
+    let heap_fsync_us = sync_heap_files_after_coalesced_flush(sync_targets)?;
+    Ok((total, pm_lock_wait_us, heap_fsync_us))
+}
+
 fn coalesced_flush_page_managers(pms: Vec<Arc<Mutex<PageManager>>>) -> DbResult<(usize, u64, u64)> {
     if pms.is_empty() {
         return Ok((0, 0, 0));
@@ -390,6 +411,26 @@ fn coalesced_flush_page_managers(pms: Vec<Arc<Mutex<PageManager>>>) -> DbResult<
 
     let heap_fsync_us = sync_heap_files_after_coalesced_flush(sync_targets)?;
     Ok((total, pm_lock_wait_us, heap_fsync_us))
+}
+
+/// Flushes PMs in `file_id` order with one PM lock per heap (dirty check inside flush).
+pub(crate) fn flush_sorted_page_managers(
+    mut entries: Vec<(u32, Arc<Mutex<PageManager>>)>,
+) -> DbResult<(usize, CommitFlushPhaseUs)> {
+    if entries.is_empty() {
+        return Ok((0, CommitFlushPhaseUs::default()));
+    }
+    entries.sort_by_key(|(file_id, _)| *file_id);
+    let pms = entries.into_iter().map(|(_, pm)| pm).collect::<Vec<_>>();
+    let (flushed, pm_lock_wait_us, heap_fsync_us) = coalesced_flush_page_managers_serial(pms)?;
+    Ok((
+        flushed,
+        CommitFlushPhaseUs {
+            table_map_lock_us: 0,
+            pm_lock_wait_us,
+            heap_fsync_us,
+        },
+    ))
 }
 
 /// Flushes dirty pages for the given physical table heaps only.
@@ -438,33 +479,22 @@ pub(crate) fn flush_page_managers_for_tables(
 
 /// Flushes dirty pages for the given page managers without acquiring `table_page_managers`.
 ///
-/// Skips managers with no dirty pages. `CommitFlushPhaseUs::table_map_lock_us` is always zero.
+/// One PM lock per manager (`flush_pm_writes_only` skips clean heaps). Serial flush avoids
+/// commit-path lock convoys under TPC-C concurrency.
 pub(crate) fn flush_page_managers_cached(
     pms: &[Arc<Mutex<PageManager>>],
 ) -> DbResult<(usize, CommitFlushPhaseUs)> {
     if pms.is_empty() {
         return Ok((0, CommitFlushPhaseUs::default()));
     }
-    let mut dirty_pms: Vec<Arc<Mutex<PageManager>>> = Vec::new();
-    let mut pm_lock_wait_us = 0u64;
+    let mut entries: Vec<(u32, Arc<Mutex<PageManager>>)> = Vec::with_capacity(pms.len());
     for pm in pms {
         let lock_t0 = Instant::now();
-        let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
-        pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
-        if dirty {
-            dirty_pms.push(pm.clone());
-        }
+        let file_id = pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX);
+        let _ = lock_t0;
+        entries.push((file_id, pm.clone()));
     }
-    dirty_pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-    let (flushed, flush_pm_wait, heap_fsync_us) = coalesced_flush_page_managers(dirty_pms)?;
-    Ok((
-        flushed,
-        CommitFlushPhaseUs {
-            table_map_lock_us: 0,
-            pm_lock_wait_us: pm_lock_wait_us.saturating_add(flush_pm_wait),
-            heap_fsync_us,
-        },
-    ))
+    flush_sorted_page_managers(entries)
 }
 
 pub(crate) fn flush_all_page_managers(


### PR DESCRIPTION
## Summary

PR #62 (touched dirty flush + parallel@2) regressed to **53.5%** RustDB/PostgreSQL ratio vs pr58 **60.8%**. Root cause: double PM lock on COMMIT (dirty pre-scan + flush) and parallel flush lock convoys (`commit_pm_lock_wait_us` p50 **57.9ms** on new_order vs pr58 **10.7ms**).

This PR (from `main`):

- Caches `file_id` in `txn_pm_cache` so COMMIT sorts heaps without extra PM locks
- **Single-pass** flush: one lock per PM via `flush_pm_writes_only` (no separate dirty scan)
- **Serial** coalesced flush on the txn-cache COMMIT path (keeps parallel flush for `flush_page_managers_for_tables` fallback)

## Test plan

- [x] `cargo fmt`, `cargo clippy -D warnings`
- [x] `flush_page_managers_*` and `explicit_transaction_selective_flush` unit tests
- [ ] CI TPC-C benchmark — target ≥60% ratio, new_order `commit_pm_lock_wait_us` p50 <20ms, `insert_order_line_us` p50 ≤35ms

## Do not merge

- PR #61 (45.4%), PR #60 (56.5%), PR #62 (53.5%) until this run is evaluated.