### PR TITLE
perf(tpcc): run-23 PR5 — restore dirty cached flush, keep file_id sort

### DIFF
--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -1,0 +1,50 @@
+name: Login to GHCR (with retry)
+description: >-
+  Authenticate to GitHub Container Registry with retries for transient
+  network timeouts (e.g. "context deadline exceeded" on ghcr.io/v2/).
+inputs:
+  registry:
+    description: Registry hostname
+    required: false
+    default: ghcr.io
+  username:
+    description: Registry username
+    required: true
+  password:
+    description: Registry password or token
+    required: true
+  max_attempts:
+    description: Maximum login attempts
+    required: false
+    default: "5"
+  retry_wait_seconds:
+    description: Seconds to wait between attempts
+    required: false
+    default: "15"
+runs:
+  using: composite
+  steps:
+    - name: Login to GHCR
+      shell: bash
+      env:
+        REGISTRY: ${{ inputs.registry }}
+        USERNAME: ${{ inputs.username }}
+        PASSWORD: ${{ inputs.password }}
+        MAX_ATTEMPTS: ${{ inputs.max_attempts }}
+        RETRY_WAIT_SECONDS: ${{ inputs.retry_wait_seconds }}
+      run: |
+        set -euo pipefail
+        attempt=1
+        while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
+          if echo "$PASSWORD" | docker login "$REGISTRY" -u "$USERNAME" --password-stdin; then
+            echo "Logged in to $REGISTRY"
+            exit 0
+          fi
+          if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
+            echo "::warning::GHCR login attempt ${attempt}/${MAX_ATTEMPTS} failed; retrying in ${RETRY_WAIT_SECONDS}s..."
+            sleep "$RETRY_WAIT_SECONDS"
+          fi
+          attempt=$((attempt + 1))
+        done
+        echo "::error::GHCR login failed after ${MAX_ATTEMPTS} attempts"
+        exit 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -267,9 +267,8 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -340,9 +339,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -384,9 +382,8 @@ jobs:
           cache-on-failure: true
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -495,9 +492,8 @@ jobs:
           cache-on-failure: true
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
@@ -756,9 +752,8 @@ jobs:
           cache-on-failure: true
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -148,7 +148,8 @@ pub struct SessionContext {
     /// Reused row serialization buffer for native TPC-C inserts in a transaction.
     pub(crate) tpcc_row_bytes_buf: Vec<u8>,
     /// Per-transaction page managers (avoids `table_page_managers` map lock on hot DML/COMMIT).
-    pub(crate) txn_pm_cache: HashMap<String, Arc<Mutex<PageManager>>>,
+    /// Value is `(heap file_id, pm)` so COMMIT can sort heaps without an extra PM lock.
+    pub(crate) txn_pm_cache: HashMap<String, (u32, Arc<Mutex<PageManager>>)>,
     /// Reused buffer for deferred index column maps (native TPC-C inserts).
     pub(crate) tpcc_index_column_map_buf: HashMap<String, String>,
     /// Last `COMMIT` flush breakdown (native TPC-C gap accounting).

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1285,8 +1285,13 @@ fn commit_transaction(
     span.record("flush_tables_count", flush_tables_count);
     let flush_clock = Instant::now();
     let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
+        let mut entries: Vec<(u32, Arc<Mutex<PageManager>>)> = ctx
+            .txn_pm_cache
+            .values()
+            .map(|(file_id, pm)| (*file_id, pm.clone()))
+            .collect();
+        entries.sort_by_key(|(file_id, _)| *file_id);
+        let pms: Vec<Arc<Mutex<PageManager>>> = entries.into_iter().map(|(_, pm)| pm).collect();
         crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
     } else if touched.is_empty() {
         (
@@ -1376,11 +1381,16 @@ fn rollback_transaction(
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
     let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
+        let mut entries: Vec<(u32, Arc<Mutex<PageManager>>)> = flush_tables
             .iter()
-            .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
+            .filter_map(|t| {
+                ctx.txn_pm_cache
+                    .get(t)
+                    .map(|(file_id, pm)| (*file_id, pm.clone()))
+            })
             .collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
+        entries.sort_by_key(|(file_id, _)| *file_id);
+        let pms: Vec<Arc<Mutex<PageManager>>> = entries.into_iter().map(|(_, pm)| pm).collect();
         crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map(|(n, _)| n)
     } else {
         crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &flush_tables)
@@ -1540,11 +1550,13 @@ pub(crate) fn table_page_manager_cached(
     ctx: &mut SessionContext,
     table: &str,
 ) -> Result<Arc<Mutex<PageManager>>, EngineError> {
-    if let Some(pm) = ctx.txn_pm_cache.get(table) {
+    if let Some((_, pm)) = ctx.txn_pm_cache.get(table) {
         return Ok(pm.clone());
     }
     let pm = table_page_manager(state, table)?;
-    ctx.txn_pm_cache.insert(table.to_string(), pm.clone());
+    let file_id = pm.lock().map_err(|_| lock_poisoned_engine())?.file_id();
+    ctx.txn_pm_cache
+        .insert(table.to_string(), (file_id, pm.clone()));
     Ok(pm)
 }
 


### PR DESCRIPTION
## Summary

PR #64 (single-pass serial commit flush) regressed full-mix TPC-C to **~51%** vs PostgreSQL (468.5 / 915.2 TPS). Root cause: serial flush of all cached page managers without dirty pre-filter, inflating `commit_pm_lock_wait_us` (new_order p50 **~108ms**) and `insert_order_line_us` (p50 **~114ms**).

This PR keeps the useful part of #64 — `(file_id, pm)` in `txn_pm_cache` for lock-free heap ordering on COMMIT — and restores **main** commit flush behavior:

- `flush_page_managers_cached`: dirty pre-scan, parallel `coalesced_flush_page_managers`
- No `flush_sorted_page_managers` / serial coalesced path

## Baseline (PR #64 CI, do not merge #64)

| Run | RustDB TPS | PG TPS | Ratio | new_order commit_pm_lock p50 | insert_order_line p50 |
|-----|------------|--------|-------|------------------------------|------------------------|
| pr58 | 548.5 | 902.6 | **60.8%** | 10.7ms | 30.5ms |
| pr62 | 485.1 | 907.6 | 53.5% | 57.9ms | 42.7ms |
| pr64 | 468.5 | 915.2 | **51.2%** | 108.0ms | 113.7ms |

## Acceptance (CI)

- Full-mix ratio **≥60%** (pr58 floor)
- new_order `commit_pm_lock_wait_us` p50 **<20ms** (stretch; pr58 was ~11ms)
- `insert_order_line_us` p50 **≤35ms**

## Next if green

- Merge #59 observability if still open
- If `commit_flush_us` remains ~100ms+: branch `tpcc-run23-pr6-*` for heap write batching in `page_manager` (phase 57)

## Test plan

- [x] `cargo fmt`, `cargo clippy -D warnings`
- [x] `cargo test --lib sql_engine` (flush + pm cache tests)
- [ ] CI TPC-C artifact run on this branch