### PR TITLE
perf(tpcc): run-23 PR6 — touched cached flush + file_id sort

### DIFF
--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -148,7 +148,8 @@ pub struct SessionContext {
     /// Reused row serialization buffer for native TPC-C inserts in a transaction.
     pub(crate) tpcc_row_bytes_buf: Vec<u8>,
     /// Per-transaction page managers (avoids `table_page_managers` map lock on hot DML/COMMIT).
-    pub(crate) txn_pm_cache: HashMap<String, Arc<Mutex<PageManager>>>,
+    /// Value is `(heap file_id, pm)` so COMMIT can sort heaps without an extra PM lock.
+    pub(crate) txn_pm_cache: HashMap<String, (u32, Arc<Mutex<PageManager>>)>,
     /// Reused buffer for deferred index column maps (native TPC-C inserts).
     pub(crate) tpcc_index_column_map_buf: HashMap<String, String>,
     /// Last `COMMIT` flush breakdown (native TPC-C gap accounting).

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1234,6 +1234,30 @@ fn begin_transaction(
     Ok(EngineOutput::ExecutionOk { rows_affected: 0 })
 }
 
+/// Flushes dirty heaps for `tables` using the transaction PM cache (no `table_page_managers` lock).
+fn flush_touched_page_managers_cached(
+    ctx: &SessionContext,
+    tables: &HashSet<String>,
+) -> Result<(usize, crate::network::sql_engine_wal::CommitFlushPhaseUs), EngineError> {
+    if tables.is_empty() {
+        return Ok((
+            0,
+            crate::network::sql_engine_wal::CommitFlushPhaseUs::default(),
+        ));
+    }
+    let mut entries: Vec<(u32, Arc<Mutex<PageManager>>)> = tables
+        .iter()
+        .filter_map(|t| {
+            ctx.txn_pm_cache
+                .get(t)
+                .map(|(file_id, pm)| (*file_id, pm.clone()))
+        })
+        .collect();
+    entries.sort_by_key(|(file_id, _)| *file_id);
+    let pms: Vec<Arc<Mutex<PageManager>>> = entries.into_iter().map(|(_, pm)| pm).collect();
+    crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)
+}
+
 fn commit_transaction(
     state: &SqlEngineState,
     ctx: &mut SessionContext,
@@ -1284,10 +1308,10 @@ fn commit_transaction(
     let flush_tables_count = touched.len();
     span.record("flush_tables_count", flush_tables_count);
     let flush_clock = Instant::now();
-    let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
+    let cache_covers_touched =
+        !ctx.txn_pm_cache.is_empty() && touched.iter().all(|t| ctx.txn_pm_cache.contains_key(t));
+    let (_flushed_pages, flush_phases) = if cache_covers_touched {
+        flush_touched_page_managers_cached(ctx, &touched)?
     } else if touched.is_empty() {
         (
             0,
@@ -1375,18 +1399,18 @@ fn rollback_transaction(
     }
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
-    let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
+    let _ = if !ctx.txn_pm_cache.is_empty()
+        && !flush_tables.is_empty()
+        && flush_tables
             .iter()
-            .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
-            .collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map(|(n, _)| n)
+            .all(|t| ctx.txn_pm_cache.contains_key(t))
+    {
+        flush_touched_page_managers_cached(ctx, &flush_tables).map(|(n, _)| n)?
     } else {
         crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &flush_tables)
             .map(|(n, _)| n)
-    }
-    .map_err(map_db_err)?;
+            .map_err(map_db_err)?
+    };
     // Only append an ABORT marker after the UNDO is applied *and* persisted.
     //
     // If we mark the transaction as aborted in WAL first and then crash before the UNDO is flushed,
@@ -1540,11 +1564,13 @@ pub(crate) fn table_page_manager_cached(
     ctx: &mut SessionContext,
     table: &str,
 ) -> Result<Arc<Mutex<PageManager>>, EngineError> {
-    if let Some(pm) = ctx.txn_pm_cache.get(table) {
+    if let Some((_, pm)) = ctx.txn_pm_cache.get(table) {
         return Ok(pm.clone());
     }
     let pm = table_page_manager(state, table)?;
-    ctx.txn_pm_cache.insert(table.to_string(), pm.clone());
+    let file_id = pm.lock().map_err(|_| lock_poisoned_engine())?.file_id();
+    ctx.txn_pm_cache
+        .insert(table.to_string(), (file_id, pm.clone()));
     Ok(pm)
 }
 


### PR DESCRIPTION
## Summary

PR #65 CI (**56.9%** vs PG) failed merge gates (ratio <60%, `commit_pm_lock_wait` 51.7ms, `insert_order_line_us` 38.5ms). #65 vs `main` only added `(file_id, pm)` in `txn_pm_cache`; COMMIT still flushed **all** cached PMs.

This PR (from `main`):

- Cache `(file_id, pm)` in `txn_pm_cache` (no extra PM lock on COMMIT sort)
- **`flush_touched_page_managers_cached`**: COMMIT/ROLLBACK flush only `touched_tables` (or rollback flush set), not entire cache
- Keeps dirty pre-scan + parallel `coalesced_flush_page_managers` from `main`

## Baseline (do not merge #60–#65)

| Run | Ratio | new_order `commit_pm_lock_wait` p50 | `insert_order_line_us` p50 |
|-----|-------|-------------------------------------|----------------------------|
| pr58 | **60.8%** | **10.7ms** | **30.5ms** |
| pr65 | 56.9% | 51.7ms | 38.5ms |

## Test plan

- [x] `cargo fmt`, `cargo clippy -D warnings`
- [x] `flush_page_managers_*` unit tests
- [ ] CI `Benchmark TPC-C throughput` — target ratio **≥60%**, `commit_pm_lock_wait` p50 **<20ms**, `insert_order_line_us` p50 **≤35ms**

## Next if flush still ~100ms+

Phase 57: heap batching in `page_manager.rs` (after stable perf, then merge #59 observability).