### PR TITLE
perf(tpcc): run-23 PR7 — presorted commit flush, one PM lock

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,8 +15,8 @@ on:
       - "LICENSE-*"
       - "architecture.puml"
       - ".editorconfig"
+  # No `branches` filter: stacked PRs (base = feature branch) must still run CI.
   pull_request:
-    branches: [main, develop]
     paths-ignore:
       - "**/*.md"
       - "docs/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,8 @@ name: "CodeQL Analysis"
 on:
   push:
     branches: [ main, develop ]
+  # No `branches` filter: stacked PRs (base = feature branch) must still run CodeQL.
   pull_request:
-    branches: [ main ]
   schedule:
     - cron: '30 1 * * 0'  # Sunday 01:30 UTC
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -3,8 +3,8 @@ name: Security Audit
 on:
   push:
     branches: [ main, develop ]
+  # No `branches` filter: stacked PRs (base = feature branch) must still run security checks.
   pull_request:
-    branches: [ main, develop ]
   schedule:
     # Daily at 02:00 UTC
     - cron: '0 2 * * *'

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1255,7 +1255,7 @@ fn flush_touched_page_managers_cached(
         .collect();
     entries.sort_by_key(|(file_id, _)| *file_id);
     let pms: Vec<Arc<Mutex<PageManager>>> = entries.into_iter().map(|(_, pm)| pm).collect();
-    crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)
+    crate::network::sql_engine_wal::flush_page_managers_presorted(pms).map_err(map_db_err)
 }
 
 fn commit_transaction(

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -436,6 +436,27 @@ pub(crate) fn flush_page_managers_for_tables(
     ))
 }
 
+/// Flushes dirty pages for `pms` already sorted by `file_id` (e.g. COMMIT touched-heaps path).
+///
+/// Skips the extra dirty pre-scan and re-sort in [`flush_page_managers_cached`] — one PM lock
+/// per heap during [`coalesced_flush_page_managers`].
+pub(crate) fn flush_page_managers_presorted(
+    pms: Vec<Arc<Mutex<PageManager>>>,
+) -> DbResult<(usize, CommitFlushPhaseUs)> {
+    if pms.is_empty() {
+        return Ok((0, CommitFlushPhaseUs::default()));
+    }
+    let (flushed, pm_lock_wait_us, heap_fsync_us) = coalesced_flush_page_managers(pms)?;
+    Ok((
+        flushed,
+        CommitFlushPhaseUs {
+            table_map_lock_us: 0,
+            pm_lock_wait_us,
+            heap_fsync_us,
+        },
+    ))
+}
+
 /// Flushes dirty pages for the given page managers without acquiring `table_page_managers`.
 ///
 /// Skips managers with no dirty pages. `CommitFlushPhaseUs::table_map_lock_us` is always zero.
@@ -750,6 +771,29 @@ mod tests {
         assert_eq!(phases.table_map_lock_us, 0);
         assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);
         assert_eq!(pm_dirty.lock().unwrap().dirty_page_count(), 0);
+
+        eng.execute_sql("COMMIT", &mut ctx).unwrap();
+    }
+
+    #[test]
+    fn flush_page_managers_presorted_flushes_dirty_without_prescan() {
+        let dir = TempDir::new().unwrap();
+        let eng = SqlEngine::open(dir.path().to_path_buf()).unwrap();
+        let state = eng.state_for_test();
+        let mut ctx = SessionContext::default();
+        eng.execute_sql("CREATE TABLE t_dirty (k INT PRIMARY KEY)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("BEGIN TRANSACTION", &mut ctx).unwrap();
+        eng.execute_sql("INSERT INTO t_dirty (k) VALUES (1)", &mut ctx)
+            .unwrap();
+
+        let pm = table_page_manager(state, "t_dirty").unwrap();
+        assert!(pm.lock().unwrap().dirty_page_count() > 0);
+
+        let (flushed, phases) = flush_page_managers_presorted(vec![pm.clone()]).unwrap();
+        assert!(flushed > 0);
+        assert_eq!(phases.table_map_lock_us, 0);
+        assert_eq!(pm.lock().unwrap().dirty_page_count(), 0);
 
         eng.execute_sql("COMMIT", &mut ctx).unwrap();
     }


### PR DESCRIPTION
## Summary
- PR66 CI: ratio **55.5%**, `commit_pm_lock_wait` new_order p50 **~50ms**, `insert_order_line` p50 **~38ms** — merge gates not met; **#66 left open**.
- COMMIT touched-cache flush now calls `flush_page_managers_presorted`: skips the extra dirty pre-scan + re-sort in `flush_page_managers_cached` (one PM lock per heap in coalesced flush).

## Context (PR66 artifacts `tpcc-artifacts-run23/pr66`)
| vs PG | TPS | ratio |
|-------|-----|-------|
| full mix | 503.6 / 907.6 | 55.5% |
| micro order_status | 4317 / 5597 | 77.1% |

new_order server p50: wall 195ms, commit 113ms, `commit_pm_lock_wait` 50ms, `commit_flush` 112ms, `insert_order_line` 38ms.

## Test plan
- [ ] CI TPC-C throughput vs PR66 / pr58 baseline
- [ ] Gate: ratio ≥60%, new_order `commit_pm_lock_wait` p50 <20ms, `insert_order_line` p50 ≤35ms