### PR TITLE
perf(tpcc): run-23 PR8 — single-pass touched dirty presorted flush

### DIFF
--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -148,7 +148,8 @@ pub struct SessionContext {
     /// Reused row serialization buffer for native TPC-C inserts in a transaction.
     pub(crate) tpcc_row_bytes_buf: Vec<u8>,
     /// Per-transaction page managers (avoids `table_page_managers` map lock on hot DML/COMMIT).
-    pub(crate) txn_pm_cache: HashMap<String, Arc<Mutex<PageManager>>>,
+    /// Value is `(heap file_id, pm)` so COMMIT can sort heaps without an extra PM lock.
+    pub(crate) txn_pm_cache: HashMap<String, (u32, Arc<Mutex<PageManager>>)>,
     /// Reused buffer for deferred index column maps (native TPC-C inserts).
     pub(crate) tpcc_index_column_map_buf: HashMap<String, String>,
     /// Last `COMMIT` flush breakdown (native TPC-C gap accounting).

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1234,6 +1234,29 @@ fn begin_transaction(
     Ok(EngineOutput::ExecutionOk { rows_affected: 0 })
 }
 
+/// Flushes dirty heaps for `tables` using the transaction PM cache (no `table_page_managers` lock).
+fn flush_touched_page_managers_cached(
+    ctx: &SessionContext,
+    tables: &HashSet<String>,
+) -> Result<(usize, crate::network::sql_engine_wal::CommitFlushPhaseUs), EngineError> {
+    if tables.is_empty() {
+        return Ok((
+            0,
+            crate::network::sql_engine_wal::CommitFlushPhaseUs::default(),
+        ));
+    }
+    let mut entries: Vec<(u32, Arc<Mutex<PageManager>>)> = tables
+        .iter()
+        .filter_map(|t| {
+            ctx.txn_pm_cache
+                .get(t)
+                .map(|(file_id, pm)| (*file_id, pm.clone()))
+        })
+        .collect();
+    entries.sort_by_key(|(file_id, _)| *file_id);
+    crate::network::sql_engine_wal::flush_touched_dirty_presorted(&entries).map_err(map_db_err)
+}
+
 fn commit_transaction(
     state: &SqlEngineState,
     ctx: &mut SessionContext,
@@ -1284,10 +1307,10 @@ fn commit_transaction(
     let flush_tables_count = touched.len();
     span.record("flush_tables_count", flush_tables_count);
     let flush_clock = Instant::now();
-    let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
+    let cache_covers_touched =
+        !ctx.txn_pm_cache.is_empty() && touched.iter().all(|t| ctx.txn_pm_cache.contains_key(t));
+    let (_flushed_pages, flush_phases) = if cache_covers_touched {
+        flush_touched_page_managers_cached(ctx, &touched)?
     } else if touched.is_empty() {
         (
             0,
@@ -1375,18 +1398,18 @@ fn rollback_transaction(
     }
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
-    let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
+    let _ = if !ctx.txn_pm_cache.is_empty()
+        && !flush_tables.is_empty()
+        && flush_tables
             .iter()
-            .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
-            .collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map(|(n, _)| n)
+            .all(|t| ctx.txn_pm_cache.contains_key(t))
+    {
+        flush_touched_page_managers_cached(ctx, &flush_tables).map(|(n, _)| n)?
     } else {
         crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &flush_tables)
             .map(|(n, _)| n)
-    }
-    .map_err(map_db_err)?;
+            .map_err(map_db_err)?
+    };
     // Only append an ABORT marker after the UNDO is applied *and* persisted.
     //
     // If we mark the transaction as aborted in WAL first and then crash before the UNDO is flushed,
@@ -1540,11 +1563,13 @@ pub(crate) fn table_page_manager_cached(
     ctx: &mut SessionContext,
     table: &str,
 ) -> Result<Arc<Mutex<PageManager>>, EngineError> {
-    if let Some(pm) = ctx.txn_pm_cache.get(table) {
+    if let Some((_, pm)) = ctx.txn_pm_cache.get(table) {
         return Ok(pm.clone());
     }
     let pm = table_page_manager(state, table)?;
-    ctx.txn_pm_cache.insert(table.to_string(), pm.clone());
+    let file_id = pm.lock().map_err(|_| lock_poisoned_engine())?.file_id();
+    ctx.txn_pm_cache
+        .insert(table.to_string(), (file_id, pm.clone()));
     Ok(pm)
 }
 

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -436,6 +436,37 @@ pub(crate) fn flush_page_managers_for_tables(
     ))
 }
 
+/// Flushes dirty heaps for `(file_id, pm)` entries already sorted by `file_id`.
+///
+/// One PM lock per heap for the dirty check; dirty heaps are flushed via
+/// [`coalesced_flush_page_managers`] (parallel when `len >= 2`).
+pub(crate) fn flush_touched_dirty_presorted(
+    entries: &[(u32, Arc<Mutex<PageManager>>)],
+) -> DbResult<(usize, CommitFlushPhaseUs)> {
+    if entries.is_empty() {
+        return Ok((0, CommitFlushPhaseUs::default()));
+    }
+    let mut dirty_pms: Vec<Arc<Mutex<PageManager>>> = Vec::new();
+    let mut pm_lock_wait_us = 0u64;
+    for (_, pm) in entries {
+        let lock_t0 = Instant::now();
+        let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
+        pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
+        if dirty {
+            dirty_pms.push(pm.clone());
+        }
+    }
+    let (flushed, flush_pm_wait, heap_fsync_us) = coalesced_flush_page_managers(dirty_pms)?;
+    Ok((
+        flushed,
+        CommitFlushPhaseUs {
+            table_map_lock_us: 0,
+            pm_lock_wait_us: pm_lock_wait_us.saturating_add(flush_pm_wait),
+            heap_fsync_us,
+        },
+    ))
+}
+
 /// Flushes dirty pages for the given page managers without acquiring `table_page_managers`.
 ///
 /// Skips managers with no dirty pages. `CommitFlushPhaseUs::table_map_lock_us` is always zero.
@@ -746,6 +777,44 @@ mod tests {
 
         let pms = vec![pm_clean.clone(), pm_dirty.clone()];
         let (flushed, phases) = flush_page_managers_cached(&pms).unwrap();
+        assert!(flushed > 0);
+        assert_eq!(phases.table_map_lock_us, 0);
+        assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);
+        assert_eq!(pm_dirty.lock().unwrap().dirty_page_count(), 0);
+
+        eng.execute_sql("COMMIT", &mut ctx).unwrap();
+    }
+
+    #[test]
+    fn flush_touched_dirty_presorted_skips_clean_and_flushes_dirty() {
+        let dir = TempDir::new().unwrap();
+        let eng = SqlEngine::open(dir.path().to_path_buf()).unwrap();
+        let state = eng.state_for_test();
+        let mut ctx = SessionContext::default();
+        eng.execute_sql("CREATE TABLE t_clean (k INT PRIMARY KEY)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("CREATE TABLE t_dirty (k INT PRIMARY KEY)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("INSERT INTO t_clean (k) VALUES (0)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("BEGIN TRANSACTION", &mut ctx).unwrap();
+        eng.execute_sql("INSERT INTO t_dirty (k) VALUES (1)", &mut ctx)
+            .unwrap();
+
+        let pm_clean = table_page_manager(state, "t_clean").unwrap();
+        let pm_dirty = table_page_manager(state, "t_dirty").unwrap();
+        assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);
+        assert!(pm_dirty.lock().unwrap().dirty_page_count() > 0);
+
+        let file_clean = pm_clean.lock().unwrap().file_id();
+        let file_dirty = pm_dirty.lock().unwrap().file_id();
+        let mut entries = vec![
+            (file_clean, pm_clean.clone()),
+            (file_dirty, pm_dirty.clone()),
+        ];
+        entries.sort_by_key(|(fid, _)| *fid);
+
+        let (flushed, phases) = flush_touched_dirty_presorted(&entries).unwrap();
         assert!(flushed > 0);
         assert_eq!(phases.table_map_lock_us, 0);
         assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);


### PR DESCRIPTION
## Summary
Combines PR6 (touched cached flush + `file_id` in `txn_pm_cache`) with a single-pass dirty presorted path — **not** PR7’s presorted flush without dirty check (which regressed payment `commit_flush` 12ms→66ms).

- `txn_pm_cache`: `HashMap<String, (u32, Arc<Mutex<PageManager>>)>` — sort by cached `file_id` without extra PM lock on commit.
- `flush_touched_page_managers_cached` (COMMIT/ROLLBACK): only **touched** tables from cache, not full `txn_pm_cache`.
- `flush_touched_dirty_presorted`: one lock per PM → dirty check → `coalesced_flush_page_managers` (parallel when `len >= 2`, same as main).
- Fallback: `flush_page_managers_for_tables` when cache does not cover all touched tables.

## Merge gates (TPC-C CI)
Do **not** merge stacked PRs #60–#67 unless PR8 CI passes:
- [ ] `ratio_vs_postgres` ≥ **60%**
- [ ] `new_order` `commit_pm_lock_wait` < **20ms**
- [ ] `insert_order_line` ≤ **35ms**

## Test plan
- [x] `cargo fmt`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` sql_engine / flush unit tests (incl. `flush_touched_dirty_presorted_skips_clean_and_flushes_dirty`)
- [ ] TPC-C throughput CI on `tpcc-run23-pr8-single-pass-dirty-presorted`

## Related
- CI stacked-PR workflow fix: #68
- Supersedes intent of PR6 + PR7 flush experiments on `main` baseline (PR #58 DML merged).