### PR TITLE
perf(tpcc): phase 41 — DML insert_order_line tail

### DIFF
--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -684,9 +684,7 @@ pub(crate) fn insert_row_tuple_tpcc_deferred(
         });
     }
     record_touched_table(ctx, table);
-    let row_bytes = tuple.to_bytes().map_err(map_db_err)?;
-    ctx.tpcc_row_bytes_buf.clear();
-    ctx.tpcc_row_bytes_buf.extend_from_slice(&row_bytes);
+    ctx.tpcc_row_bytes_buf = tuple.to_bytes().map_err(map_db_err)?;
     let pm_for_table = table_page_manager_cached(state, ctx, table)?;
     let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
     let ins = pm.insert(&ctx.tpcc_row_bytes_buf).map_err(map_db_err)?;

--- a/src/network/sql_engine/tpcc_native.rs
+++ b/src/network/sql_engine/tpcc_native.rs
@@ -46,6 +46,21 @@ fn new_tuple_with_columns(id: u64, cols: &[(&str, i32)]) -> Tuple {
     tuple
 }
 
+fn new_order_line_tuple(id: u64, o_id: i32, d_id: i32, w_id: i32, i_id: i32, qty: i32) -> Tuple {
+    new_tuple_with_columns(
+        id,
+        &[
+            ("ol_o_id", o_id),
+            ("ol_d_id", d_id),
+            ("ol_w_id", w_id),
+            ("ol_number", 1),
+            ("ol_i_id", i_id),
+            ("ol_qty", qty),
+            ("ol_amount", qty * 10),
+        ],
+    )
+}
+
 fn phase_elapsed_us(t0: Instant) -> u64 {
     t0.elapsed().as_micros() as u64
 }
@@ -172,18 +187,7 @@ fn run_new_order_native(
         state,
         ctx,
         "order_line",
-        new_tuple_with_columns(
-            id,
-            &[
-                ("ol_o_id", o_id as i32),
-                ("ol_d_id", d_id),
-                ("ol_w_id", w_id),
-                ("ol_number", 1),
-                ("ol_i_id", i_id),
-                ("ol_qty", qty),
-                ("ol_amount", qty * 10),
-            ],
-        ),
+        new_order_line_tuple(id, o_id as i32, d_id, w_id, i_id, qty),
     )?;
     wal_insert_us += ins.wal_us;
     index_sync_us += ins.index_us;


### PR DESCRIPTION
## Summary

Phase 41 (run-24): shrink native `new_order` DML tail on `order_line` heap insert (continues #58 deferred-index line).

- **`insert_row_tuple_tpcc_deferred`:** serialize row once into `SessionContext::tpcc_row_bytes_buf` (no `to_bytes` + `extend` double copy).
- **	pcc_native:** `new_order_line_tuple` for the `order_line` insert path.

## Goals / acceptance

| Metric | Target |
|--------|--------|
| `phases_sum` p50 (new_order DML) | <35 ms |
| Full-mix vs PostgreSQL ratio | +1–2 pp vs baseline |

## Out of scope

Commit flush / PM lock (phase 40), PR #69 bisect (phase 42).

## Test plan

- [x] `cargo fmt`, `cargo clippy -- -D warnings`
- [x] `cargo test sql_engine`
- [ ] `bench_tpcc_throughput` — `insert_order_line_us` in `sql.execute_tpcc.new_order`

## Merge order

**After phase 40** (independent branch from `main`; can merge in parallel once 40 is green).

Made with [Cursor](https://cursor.com)