### PR TITLE
perf(tpcc): exp — parking_lot Mutex on PageManager + optional PM sharding

### DIFF
--- a/examples/join_operators_example.rs
+++ b/examples/join_operators_example.rs
@@ -5,21 +5,21 @@ use rustdb::executor::{
     HashJoinOperator, JoinCondition, JoinOperator, JoinType, MergeJoinOperator,
     NestedLoopJoinOperator, Operator, TableScanOperator,
 };
-use rustdb::storage::page_manager::{PageManager, PageManagerConfig};
+use rustdb::storage::page_manager::{PageManager, PageManagerConfig, PageManagerMutex};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 fn main() -> Result<()> {
     println!("=== Example of using join operators ===\n");
 
     // Creating page managers for different tables
-    let users_page_manager = Arc::new(Mutex::new(PageManager::new(
+    let users_page_manager = Arc::new(PageManagerMutex::new(PageManager::new(
         PathBuf::from("./data"),
         "users",
         PageManagerConfig::default(),
     )?));
 
-    let emails_page_manager = Arc::new(Mutex::new(PageManager::new(
+    let emails_page_manager = Arc::new(PageManagerMutex::new(PageManager::new(
         PathBuf::from("./data"),
         "emails",
         PageManagerConfig::default(),

--- a/examples/scan_operators_example.rs
+++ b/examples/scan_operators_example.rs
@@ -7,7 +7,7 @@ use rustdb::executor::{
 // removed unused imports
 use rustdb::common::Result;
 use rustdb::storage::index::BPlusTree;
-use rustdb::storage::page_manager::{PageManager, PageManagerConfig};
+use rustdb::storage::page_manager::{PageManager, PageManagerConfig, PageManagerMutex};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -15,7 +15,7 @@ fn main() -> Result<()> {
     println!("=== Example of using scan operators ===\n");
 
     // Creating a page manager
-    let page_manager = Arc::new(Mutex::new(PageManager::new(
+    let page_manager = Arc::new(PageManagerMutex::new(PageManager::new(
         PathBuf::from("./data"),
         "users",
         PageManagerConfig::default(),

--- a/src/executor/operators.rs
+++ b/src/executor/operators.rs
@@ -11,8 +11,8 @@ use crate::planner::{ExecutionPlan, PlanNode};
 use crate::storage::index::BPlusTree;
 use crate::storage::index::Index;
 use crate::storage::index_registry::IndexRegistry;
-use crate::storage::page_manager::PageManager as StoragePageManager;
 use crate::storage::page_manager::PageManagerConfig;
+use crate::storage::page_manager::{PageManager as StoragePageManager, PageManagerMutex};
 use crate::storage::tuple::Tuple;
 use crate::{RecordId, Row};
 
@@ -323,7 +323,7 @@ impl Operator for GroupByOperator {
 pub struct TableScanOperator {
     #[allow(dead_code)]
     table_name: String,
-    page_manager: Arc<Mutex<StoragePageManager>>,
+    page_manager: Arc<PageManagerMutex>,
     filter_condition: Option<String>,
     pushdown_equality: Option<SimpleEqualityFilter>,
     /// Projection column names from the plan (`*` = all tuple columns).
@@ -340,7 +340,7 @@ impl TableScanOperator {
     /// Create new table scan operator
     pub fn new(
         table_name: String,
-        page_manager: Arc<Mutex<StoragePageManager>>,
+        page_manager: Arc<PageManagerMutex>,
         filter_condition: Option<String>,
         pushdown_equality: Option<SimpleEqualityFilter>,
         schema: Vec<String>,
@@ -368,10 +368,7 @@ impl TableScanOperator {
             table = %self.table_name
         );
         let _g = span.enter();
-        let mut pm = self
-            .page_manager
-            .lock()
-            .map_err(|_| Error::lock("page manager poisoned"))?;
+        let mut pm = self.page_manager.lock();
         let ids = pm.all_page_ids()?;
         self.statistics.io_operations = self.statistics.io_operations.saturating_add(1);
         self.page_ids = Some(ids);
@@ -398,10 +395,7 @@ impl TableScanOperator {
         );
         let _g = span.enter();
 
-        let mut pm = self
-            .page_manager
-            .lock()
-            .map_err(|_| Error::lock("page manager poisoned"))?;
+        let mut pm = self.page_manager.lock();
         self.page_records = pm.records_from_page(page_id)?;
         self.record_pos = 0;
         self.statistics.io_operations = self.statistics.io_operations.saturating_add(1);
@@ -570,7 +564,7 @@ pub struct IndexScanOperator {
     /// Index for scanning: key = column value, value = list of record IDs
     index: Arc<Mutex<BPlusTree<String, Vec<RecordId>>>>,
     /// Page manager
-    page_manager: Arc<Mutex<StoragePageManager>>,
+    page_manager: Arc<PageManagerMutex>,
     /// Search conditions
     search_conditions: Vec<IndexCondition>,
     /// Current position in index result
@@ -612,7 +606,7 @@ impl IndexScanOperator {
         table_name: String,
         index_name: String,
         index: Arc<Mutex<BPlusTree<String, Vec<RecordId>>>>,
-        page_manager: Arc<Mutex<StoragePageManager>>,
+        page_manager: Arc<PageManagerMutex>,
         search_conditions: Vec<IndexCondition>,
         schema: Vec<String>,
     ) -> Result<Self> {
@@ -709,10 +703,7 @@ impl IndexScanOperator {
 
     /// Load record by ID from PageManager
     fn load_record(&mut self, record_id: RecordId) -> Result<Option<Row>> {
-        let mut pm = self
-            .page_manager
-            .lock()
-            .map_err(|_| Error::internal("Lock poisoned"))?;
+        let mut pm = self.page_manager.lock();
         let data = pm.get_record(record_id)?;
         self.statistics.io_operations += 1;
 
@@ -2358,8 +2349,8 @@ impl Operator for OffsetOperator {
 /// Factory for creating scan operators
 pub struct ScanOperatorFactory {
     /// Page manager
-    default_page_manager: Arc<Mutex<StoragePageManager>>,
-    table_page_managers: Arc<Mutex<HashMap<String, Arc<Mutex<StoragePageManager>>>>>,
+    default_page_manager: Arc<PageManagerMutex>,
+    table_page_managers: Arc<Mutex<HashMap<String, Arc<PageManagerMutex>>>>,
     /// Indexes: (table_name, index_name) -> B+ tree (used when `index_registry` is `None`, e.g. tests)
     indexes: Mutex<HashMap<(String, String), Arc<Mutex<BPlusTree<String, Vec<RecordId>>>>>>,
     /// When set, `CREATE INDEX` / DML maintain this registry and index scans resolve through it.
@@ -2373,7 +2364,7 @@ pub struct ScanOperatorFactory {
 
 impl ScanOperatorFactory {
     /// Create new scan operator factory
-    pub fn new(page_manager: Arc<Mutex<StoragePageManager>>) -> Self {
+    pub fn new(page_manager: Arc<PageManagerMutex>) -> Self {
         Self {
             default_page_manager: page_manager,
             table_page_managers: Arc::new(Mutex::new(HashMap::new())),
@@ -2385,8 +2376,8 @@ impl ScanOperatorFactory {
     }
 
     pub fn with_tables(
-        default_page_manager: Arc<Mutex<StoragePageManager>>,
-        table_page_managers: Arc<Mutex<HashMap<String, Arc<Mutex<StoragePageManager>>>>>,
+        default_page_manager: Arc<PageManagerMutex>,
+        table_page_managers: Arc<Mutex<HashMap<String, Arc<PageManagerMutex>>>>,
         data_dir: PathBuf,
         index_registry: Option<Arc<RwLock<IndexRegistry>>>,
     ) -> Self {
@@ -2400,7 +2391,7 @@ impl ScanOperatorFactory {
         }
     }
 
-    fn page_manager_for_table(&self, table_name: &str) -> Result<Arc<Mutex<StoragePageManager>>> {
+    fn page_manager_for_table(&self, table_name: &str) -> Result<Arc<PageManagerMutex>> {
         let mut g = self
             .table_page_managers
             .lock()
@@ -2411,8 +2402,8 @@ impl ScanOperatorFactory {
         if let Some(ref dir) = self.data_dir {
             let pm = match StoragePageManager::open(dir.clone(), table_name, self.pm_config.clone())
             {
-                Ok(pm) => Arc::new(Mutex::new(pm)),
-                Err(_) => Arc::new(Mutex::new(StoragePageManager::new(
+                Ok(pm) => Arc::new(PageManagerMutex::new(pm)),
+                Err(_) => Arc::new(PageManagerMutex::new(StoragePageManager::new(
                     dir.clone(),
                     table_name,
                     self.pm_config.clone(),
@@ -2428,7 +2419,7 @@ impl ScanOperatorFactory {
     pub fn register_table_page_manager(
         &self,
         table_name: &str,
-        pm: Arc<Mutex<StoragePageManager>>,
+        pm: Arc<PageManagerMutex>,
     ) -> Result<()> {
         let mut g = self
             .table_page_managers

--- a/src/executor/tests/common/mod.rs
+++ b/src/executor/tests/common/mod.rs
@@ -1,22 +1,22 @@
 //! Common test utilities for executor tests
 
 use crate::common::types::{ColumnValue, DataType};
-use crate::storage::page_manager::{PageManager, PageManagerConfig};
+use crate::storage::page_manager::{PageManager, PageManagerConfig, PageManagerMutex};
 use crate::storage::tuple::Tuple;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tempfile::TempDir;
 
 /// Creates a PageManager in a temporary directory for testing
-pub fn create_test_page_manager() -> (TempDir, Arc<Mutex<PageManager>>) {
+pub fn create_test_page_manager() -> (TempDir, Arc<PageManagerMutex>) {
     let temp_dir = TempDir::new().unwrap();
     let data_path = temp_dir.path().to_path_buf();
     let pm = PageManager::new(data_path, "test_table", PageManagerConfig::default()).unwrap();
-    (temp_dir, Arc::new(Mutex::new(pm)))
+    (temp_dir, Arc::new(PageManagerMutex::new(pm)))
 }
 
 /// Inserts `n` tuples with columns `id` (Integer) and `data` (Varchar), for table-scan executor tests.
-pub fn seed_id_data_rows(pm: &Arc<Mutex<PageManager>>, n: usize) {
-    let mut pm = pm.lock().expect("pm");
+pub fn seed_id_data_rows(pm: &Arc<PageManagerMutex>, n: usize) {
+    let mut pm = pm.lock();
     for i in 0..n {
         let mut t = Tuple::new((i + 1) as u64);
         t.set_value("id", ColumnValue::new(DataType::Integer(i as i32 + 1)));

--- a/src/executor/tests/executor_tests.rs
+++ b/src/executor/tests/executor_tests.rs
@@ -39,7 +39,7 @@ fn test_executor_simple_table_scan() -> Result<()> {
     // Insert test data
     {
         let data = b"1\tAlice\t30".to_vec();
-        let mut pm = page_manager.lock().unwrap();
+        let mut pm = page_manager.lock();
         pm.insert(&data)?;
     }
 

--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -31,9 +31,9 @@ pub mod engine_error_code {
 }
 
 use crate::common::types::RecordId;
-use crate::storage::page_manager::PageManager;
+use crate::storage::page_manager::{PageManager, PageManagerMutex};
 use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 /// Isolation level for the SQL engine session transaction (`BEGIN` … `COMMIT`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -148,7 +148,7 @@ pub struct SessionContext {
     /// Reused row serialization buffer for native TPC-C inserts in a transaction.
     pub(crate) tpcc_row_bytes_buf: Vec<u8>,
     /// Per-transaction page managers (avoids `table_page_managers` map lock on hot DML/COMMIT).
-    pub(crate) txn_pm_cache: HashMap<String, Arc<Mutex<PageManager>>>,
+    pub(crate) txn_pm_cache: HashMap<String, Arc<PageManagerMutex>>,
     /// Reused buffer for deferred index column maps (native TPC-C inserts).
     pub(crate) tpcc_index_column_map_buf: HashMap<String, String>,
     /// Last `COMMIT` flush breakdown (native TPC-C gap accounting).

--- a/src/network/sql_engine/alter_table_ops.rs
+++ b/src/network/sql_engine/alter_table_ops.rs
@@ -185,35 +185,20 @@ where
     F: FnMut(&mut Tuple) -> Result<(), EngineError>,
 {
     let pm = table_page_manager(state, table)?;
-    let snapshot = pm
-        .lock()
-        .map_err(|_| lock_poisoned_engine())?
-        .select(None)
-        .map_err(map_db_err)?;
+    let snapshot = pm.lock().select(None).map_err(map_db_err)?;
     for (rid, data) in snapshot {
         let mut t = Tuple::from_bytes(&data).map_err(map_db_err)?;
         f(&mut t)?;
         let bytes = t.to_bytes().map_err(map_db_err)?;
-        pm.lock()
-            .map_err(|_| lock_poisoned_engine())?
-            .update(rid, &bytes)
-            .map_err(map_db_err)?;
+        pm.lock().update(rid, &bytes).map_err(map_db_err)?;
     }
-    pm.lock()
-        .map_err(|_| lock_poisoned_engine())?
-        .flush_dirty_pages()
-        .map_err(map_db_err)?;
+    pm.lock().flush_dirty_pages().map_err(map_db_err)?;
     Ok(())
 }
 
 fn row_count(state: &SqlEngineState, table: &str) -> Result<usize, EngineError> {
     let pm = table_page_manager(state, table)?;
-    let n = pm
-        .lock()
-        .map_err(|_| lock_poisoned_engine())?
-        .select(None)
-        .map_err(map_db_err)?
-        .len();
+    let n = pm.lock().select(None).map_err(map_db_err)?.len();
     Ok(n)
 }
 
@@ -647,11 +632,7 @@ pub(super) fn modify_column(
 
     if new_col.not_null && !old_snap.not_null {
         let pm = table_page_manager(state, table)?;
-        let snapshot = pm
-            .lock()
-            .map_err(|_| lock_poisoned_engine())?
-            .select(None)
-            .map_err(map_db_err)?;
+        let snapshot = pm.lock().select(None).map_err(map_db_err)?;
         for (_, data) in snapshot {
             let t = Tuple::from_bytes(&data).map_err(map_db_err)?;
             let bad = match t.values.get(&col_name) {

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -74,7 +74,7 @@ use crate::parser::{SqlParser, SqlStatement};
 use crate::planner::planner::IndexScanNode;
 use crate::planner::{ExecutionPlan, PlanNode, QueryOptimizer, QueryPlanner};
 use crate::storage::index_registry::IndexRegistry;
-use crate::storage::page_manager::{PageManager, PageManagerConfig};
+use crate::storage::page_manager::{PageManager, PageManagerConfig, PageManagerMutex};
 use crate::storage::row_locks::RowLockManager;
 use crate::storage::tuple::Tuple;
 use crate::Row;
@@ -170,8 +170,8 @@ impl Default for SqlEngineConfig {
 pub(crate) struct SqlEngineState {
     data_dir: PathBuf,
     durability: DurabilityMode,
-    pub(crate) default_page_manager: Arc<Mutex<PageManager>>,
-    pub(crate) table_page_managers: Arc<Mutex<HashMap<String, Arc<Mutex<PageManager>>>>>,
+    pub(crate) default_page_manager: Arc<PageManagerMutex>,
+    pub(crate) table_page_managers: Arc<Mutex<HashMap<String, Arc<PageManagerMutex>>>>,
     /// Monotonic id assigned to inserted [`Tuple`] rows (persisted in tuple bytes).
     next_tuple_id: AtomicU64,
     planner: QueryPlanner,
@@ -230,8 +230,8 @@ impl SqlEngine {
             Ok(pm) => pm,
             Err(_) => PageManager::new(data_dir.clone(), "default", PageManagerConfig::default())?,
         };
-        let pm = Arc::new(Mutex::new(pm));
-        let table_pms: Arc<Mutex<HashMap<String, Arc<Mutex<PageManager>>>>> =
+        let pm = Arc::new(PageManagerMutex::new(pm));
+        let table_pms: Arc<Mutex<HashMap<String, Arc<PageManagerMutex>>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let index_registry = Arc::new(RwLock::new(IndexRegistry::new()));
         let factory = Arc::new(ScanOperatorFactory::with_tables(
@@ -688,7 +688,7 @@ pub(crate) fn insert_row_tuple_tpcc_deferred(
     ctx.tpcc_row_bytes_buf.clear();
     ctx.tpcc_row_bytes_buf.extend_from_slice(&row_bytes);
     let pm_for_table = table_page_manager_cached(state, ctx, table)?;
-    let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm_for_table.lock();
     let ins = pm.insert(&ctx.tpcc_row_bytes_buf).map_err(map_db_err)?;
     maybe_simulate_dml_crash("insert_row");
     let mut payload = std::mem::take(&mut ctx.tpcc_row_bytes_buf);
@@ -742,7 +742,7 @@ fn insert_row_tuple_tpcc_immediate(
     record_touched_table(ctx, table);
     let bytes = tuple.to_bytes().map_err(map_db_err)?;
     let pm_for_table = table_page_manager(state, table)?;
-    let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm_for_table.lock();
     let ins = pm.insert(&bytes).map_err(map_db_err)?;
     maybe_simulate_dml_crash("insert_row");
     let wal_clock = state.wal.is_some().then(Instant::now);
@@ -1285,8 +1285,8 @@ fn commit_transaction(
     span.record("flush_tables_count", flush_tables_count);
     let flush_clock = Instant::now();
     let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
+        let mut pms: Vec<Arc<PageManagerMutex>> = ctx.txn_pm_cache.values().cloned().collect();
+        pms.sort_by_key(|pm| pm.lock().file_id());
         crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
     } else if touched.is_empty() {
         (
@@ -1376,11 +1376,11 @@ fn rollback_transaction(
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
     let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
+        let mut pms: Vec<Arc<PageManagerMutex>> = flush_tables
             .iter()
             .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
             .collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
+        pms.sort_by_key(|pm| pm.lock().file_id());
         crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map(|(n, _)| n)
     } else {
         crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &flush_tables)
@@ -1448,7 +1448,7 @@ fn apply_undo(state: &SqlEngineState, op: UndoEntry) -> Result<(), EngineError> 
                     .map_err(|_| lock_poisoned_engine())?;
                 sql_constraints::unregister_row(&mut rt, &table, rid, &tuple, s, &cat_clone)?;
             }
-            let mut g = pm.lock().map_err(|_| lock_poisoned_engine())?;
+            let mut g = pm.lock();
             match g.delete(rid) {
                 Ok(_) => {}
                 Err(e) => {
@@ -1479,7 +1479,7 @@ fn apply_undo(state: &SqlEngineState, op: UndoEntry) -> Result<(), EngineError> 
             payload,
         } => {
             let pm = table_page_manager(state, &table)?;
-            let mut g = pm.lock().map_err(|_| lock_poisoned_engine())?;
+            let mut g = pm.lock();
             let _ins = g.insert(&payload).map_err(map_db_err)?;
         }
         UndoEntry::Update {
@@ -1488,7 +1488,7 @@ fn apply_undo(state: &SqlEngineState, op: UndoEntry) -> Result<(), EngineError> 
             old_payload,
         } => {
             let pm = table_page_manager(state, &table)?;
-            let mut g = pm.lock().map_err(|_| lock_poisoned_engine())?;
+            let mut g = pm.lock();
             g.update(rid, &old_payload).map_err(map_db_err)?;
         }
     }
@@ -1499,16 +1499,14 @@ pub(crate) fn table_has_dirty_heap_pages(state: &SqlEngineState, table: &str) ->
     let Ok(pm) = table_page_manager(state, table) else {
         return false;
     };
-    let Ok(guard) = pm.lock() else {
-        return false;
-    };
+    let guard = pm.lock();
     guard.dirty_page_count() > 0
 }
 
 pub(crate) fn table_page_manager(
     state: &SqlEngineState,
     table: &str,
-) -> Result<Arc<Mutex<PageManager>>, EngineError> {
+) -> Result<Arc<PageManagerMutex>, EngineError> {
     {
         let g = state
             .table_page_managers
@@ -1523,7 +1521,7 @@ pub(crate) fn table_page_manager(
         Err(_) => PageManager::new(state.data_dir.clone(), table, PageManagerConfig::default())
             .map_err(map_db_err)?,
     };
-    let pm = Arc::new(Mutex::new(pm));
+    let pm = Arc::new(PageManagerMutex::new(pm));
     {
         let mut g = state
             .table_page_managers
@@ -1539,7 +1537,7 @@ pub(crate) fn table_page_manager_cached(
     state: &SqlEngineState,
     ctx: &mut SessionContext,
     table: &str,
-) -> Result<Arc<Mutex<PageManager>>, EngineError> {
+) -> Result<Arc<PageManagerMutex>, EngineError> {
     if let Some(pm) = ctx.txn_pm_cache.get(table) {
         return Ok(pm.clone());
     }
@@ -1704,11 +1702,7 @@ fn physical_drop_table(state: &SqlEngineState, table: &str) -> Result<(), Engine
     };
     if let Some(ref sch) = schema {
         let pm = table_page_manager(state, table)?;
-        let snapshot = pm
-            .lock()
-            .map_err(|_| lock_poisoned_engine())?
-            .select(None)
-            .map_err(map_db_err)?;
+        let snapshot = pm.lock().select(None).map_err(map_db_err)?;
         let mut rt = state
             .constraint_runtime
             .lock()
@@ -2273,11 +2267,7 @@ fn backfill_index_from_heap(
     index_name: &str,
 ) -> Result<(), EngineError> {
     let pm = table_page_manager(state, table)?;
-    let snapshot = pm
-        .lock()
-        .map_err(|_| lock_poisoned_engine())?
-        .select(None)
-        .map_err(map_db_err)?;
+    let snapshot = pm.lock().select(None).map_err(map_db_err)?;
     let mut ir = state
         .index_registry
         .write()
@@ -2344,7 +2334,7 @@ fn execute_insert(
                 )?;
             }
             {
-                let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+                let mut pm = pm_for_table.lock();
                 flush_heap_after_dml_success(state, ctx, &mut pm)?;
             }
             Ok(EngineOutput::ExecutionOk { rows_affected })
@@ -2363,7 +2353,7 @@ fn execute_insert(
                 )?;
             }
             {
-                let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+                let mut pm = pm_for_table.lock();
                 flush_heap_after_dml_success(state, ctx, &mut pm)?;
             }
             Ok(EngineOutput::ExecutionOk { rows_affected })
@@ -2444,7 +2434,7 @@ fn execute_update(
     validate_plan(state, sql, stmt)?;
     record_touched_table(ctx, &update.table);
     let pm_for_table = table_page_manager(state, &update.table)?;
-    let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm_for_table.lock();
     let scan_clock = sql_phase_log_enabled().then(Instant::now);
     let (snapshot, where_pre_filtered) = match &update.where_clause {
         None => (pm.select(None).map_err(map_db_err)?, false),
@@ -2606,7 +2596,7 @@ fn execute_delete(
     validate_plan(state, sql, stmt)?;
     record_touched_table(ctx, &delete.table);
     let pm_for_table = table_page_manager(state, &delete.table)?;
-    let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm_for_table.lock();
     let scan_clock = sql_phase_log_enabled().then(Instant::now);
     let (snapshot, where_pre_filtered) = match &delete.where_clause {
         None => (pm.select(None).map_err(map_db_err)?, false),
@@ -3068,11 +3058,7 @@ fn rebuild_all_constraint_runtime(state: &SqlEngineState) -> Result<(), EngineEr
     for t in order {
         let schema = cat.schema(&t).expect("schema").clone();
         let pm = table_page_manager(state, &t)?;
-        let snapshot = pm
-            .lock()
-            .map_err(|_| lock_poisoned_engine())?
-            .select(None)
-            .map_err(map_db_err)?;
+        let snapshot = pm.lock().select(None).map_err(map_db_err)?;
         let mut rt = state
             .constraint_runtime
             .lock()
@@ -3290,7 +3276,7 @@ fn insert_row_tuple_inner(
     record_touched_table(ctx, table);
     let bytes = tuple.to_bytes().map_err(map_db_err)?;
     let pm_for_table = table_page_manager(state, table)?;
-    let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm_for_table.lock();
     let ins = pm.insert(&bytes).map_err(map_db_err)?;
     maybe_simulate_dml_crash("insert_row");
     if let Some(tx) = ctx.transaction.as_mut() {
@@ -3393,7 +3379,7 @@ fn insert_heap_row_pk_serialized(
     ctx: &mut SessionContext,
     table: &str,
     tuple: &Tuple,
-    pm_for_table: &Arc<Mutex<PageManager>>,
+    pm_for_table: &Arc<PageManagerMutex>,
 ) -> Result<u64, EngineError> {
     let mut rt = state
         .constraint_runtime
@@ -3404,7 +3390,7 @@ fn insert_heap_row_pk_serialized(
         drop(cat);
         drop(rt);
         let bytes = tuple.to_bytes().map_err(map_db_err)?;
-        let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+        let mut pm = pm_for_table.lock();
         let ins = pm.insert(&bytes).map_err(map_db_err)?;
         insert_heap_row_after_bytes(state, ctx, table, tuple, &mut pm, bytes, ins)?;
         return Ok(1);
@@ -3415,7 +3401,7 @@ fn insert_heap_row_pk_serialized(
     sql_constraints::validate_new_row_for_insert(&rt, table, tuple, &schema, &snapshot)?;
 
     let bytes = tuple.to_bytes().map_err(map_db_err)?;
-    let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm_for_table.lock();
     let ins = pm.insert(&bytes).map_err(map_db_err)?;
     maybe_simulate_dml_crash("insert_row");
     if let Some(tx) = ctx.transaction.as_mut() {
@@ -3474,14 +3460,14 @@ fn insert_heap_row_in_execute_insert(
     ctx: &mut SessionContext,
     table: &str,
     tuple: &Tuple,
-    pm_for_table: &Arc<Mutex<PageManager>>,
+    pm_for_table: &Arc<PageManagerMutex>,
 ) -> Result<u64, EngineError> {
     if table_has_primary_key(state, table) {
         return insert_heap_row_pk_serialized(state, ctx, table, tuple, pm_for_table);
     }
     insert_row_with_optional_pk_lock(state, table, tuple, || {
         let bytes = tuple.to_bytes().map_err(map_db_err)?;
-        let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+        let mut pm = pm_for_table.lock();
         let ins = pm.insert(&bytes).map_err(map_db_err)?;
         insert_heap_row_after_bytes(state, ctx, table, tuple, &mut pm, bytes, ins)?;
         Ok(1u64)
@@ -3509,7 +3495,7 @@ where
 {
     record_touched_table(ctx, table);
     let pm_for_table = table_page_manager_cached(state, ctx, table)?;
-    let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm_for_table.lock();
     let (rows, exact_key) = {
         let ir = state
             .index_registry
@@ -3546,7 +3532,7 @@ where
     };
 
     let apply = move || -> Result<u64, EngineError> {
-        let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+        let mut pm = pm_for_table.lock();
         let mut rows_affected = 0u64;
         for (rid, data) in rows {
             let mut tuple = Tuple::from_bytes(&data).map_err(map_db_err)?;
@@ -3669,7 +3655,7 @@ pub(crate) fn delete_rows_by_equalities(
 ) -> Result<u64, EngineError> {
     record_touched_table(ctx, table);
     let pm_for_table = table_page_manager_cached(state, ctx, table)?;
-    let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm_for_table.lock();
     let (rows, exact_key) = {
         let ir = state
             .index_registry
@@ -3707,7 +3693,7 @@ pub(crate) fn delete_rows_by_equalities(
 
     let batch_index = !exact_key && rows.len() > 1;
     let apply = move || -> Result<u64, EngineError> {
-        let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
+        let mut pm = pm_for_table.lock();
         let cat_snapshot = {
             let cat = state.catalog.lock().map_err(|_| lock_poisoned_engine())?;
             cat.clone()
@@ -3817,7 +3803,7 @@ pub(crate) fn tpcc_order_status_row_count(
     }
     drop(ir);
     let pm = table_page_manager(state, "oorder")?;
-    let mut pm = pm.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm.lock();
     let mut count = 0u64;
     for rid in rids {
         if pm.get_record(rid).map_err(map_db_err)?.is_some() {
@@ -3846,7 +3832,7 @@ pub(crate) fn tpcc_stock_level_row_count(
     };
     drop(ir);
     let pm = table_page_manager(state, "stock")?;
-    let mut pm = pm.lock().map_err(|_| lock_poisoned_engine())?;
+    let mut pm = pm.lock();
     let mut count = 0u64;
     for rid in rids {
         let Some(data) = pm.get_record(rid).map_err(map_db_err)? else {
@@ -4925,24 +4911,24 @@ mod tests {
         eng.execute_sql("INSERT INTO tb (k) VALUES (0)", &mut ctx)
             .unwrap();
         let pm_b = table_page_manager(eng.state_for_test(), "tb").unwrap();
-        assert_eq!(pm_b.lock().unwrap().dirty_page_count(), 0);
+        assert_eq!(pm_b.lock().dirty_page_count(), 0);
 
         eng.execute_sql("BEGIN TRANSACTION", &mut ctx).unwrap();
         eng.execute_sql("INSERT INTO ta (k) VALUES (1)", &mut ctx)
             .unwrap();
         let pm_a = table_page_manager(eng.state_for_test(), "ta").unwrap();
         assert!(
-            pm_a.lock().unwrap().dirty_page_count() > 0,
+            pm_a.lock().dirty_page_count() > 0,
             "touched table ta should have dirty pages before COMMIT"
         );
         assert_eq!(
-            pm_b.lock().unwrap().dirty_page_count(),
+            pm_b.lock().dirty_page_count(),
             0,
             "untouched table tb should not be flushed mid-txn"
         );
         eng.execute_sql("COMMIT", &mut ctx).unwrap();
-        assert_eq!(pm_a.lock().unwrap().dirty_page_count(), 0);
-        assert_eq!(pm_b.lock().unwrap().dirty_page_count(), 0);
+        assert_eq!(pm_a.lock().dirty_page_count(), 0);
+        assert_eq!(pm_b.lock().dirty_page_count(), 0);
     }
 
     #[test]
@@ -4958,13 +4944,13 @@ mod tests {
         eng.execute_sql("INSERT INTO defer_flush (k) VALUES (2)", &mut ctx)
             .unwrap();
         let pm = table_page_manager(eng.state_for_test(), "defer_flush").unwrap();
-        let dirty_mid_txn = pm.lock().expect("page manager lock").dirty_page_count();
+        let dirty_mid_txn = pm.lock().dirty_page_count();
         assert!(
             dirty_mid_txn > 0,
             "expected dirty heap pages before COMMIT, got {dirty_mid_txn}"
         );
         eng.execute_sql("COMMIT", &mut ctx).unwrap();
-        let dirty_after_commit = pm.lock().unwrap().dirty_page_count();
+        let dirty_after_commit = pm.lock().dirty_page_count();
         assert_eq!(
             dirty_after_commit, 0,
             "COMMIT should flush dirty heap pages"

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -9,7 +9,7 @@ use crate::logging::log_record::{
 use crate::logging::log_writer::{LogWriter, LogWriterConfig};
 use crate::logging::recovery::{RecoveryConfig, RecoveryManager};
 use crate::network::engine::{engine_error_code, EngineError, SqlIsolationLevel, SqlTransaction};
-use crate::storage::page_manager::PageManager;
+use crate::storage::page_manager::{PageManager, PageManagerMutex};
 use rayon::prelude::*;
 use std::collections::HashSet;
 use std::path::Path;
@@ -319,11 +319,9 @@ pub(crate) struct CommitFlushPhaseUs {
     pub heap_fsync_us: u64,
 }
 
-fn flush_pm_writes_only(pm: &Arc<Mutex<PageManager>>) -> DbResult<(usize, Option<u32>, u64)> {
+fn flush_pm_writes_only(pm: &Arc<PageManagerMutex>) -> DbResult<(usize, Option<u32>, u64)> {
     let lock_t0 = Instant::now();
-    let mut guard = pm
-        .lock()
-        .map_err(|_| DbError::database("table page manager lock poisoned"))?;
+    let mut guard = pm.lock();
     let pm_lock_wait_us = lock_t0.elapsed().as_micros() as u64;
     if guard.dirty_page_count() == 0 {
         return Ok((0, None, pm_lock_wait_us));
@@ -336,7 +334,7 @@ fn flush_pm_writes_only(pm: &Arc<Mutex<PageManager>>) -> DbResult<(usize, Option
 }
 
 fn sync_heap_files_after_coalesced_flush(
-    sync_targets: Vec<(u32, Arc<Mutex<PageManager>>)>,
+    sync_targets: Vec<(u32, Arc<PageManagerMutex>)>,
 ) -> DbResult<u64> {
     if bench_defer_heap_fsync_enabled() {
         return Ok(0);
@@ -349,7 +347,6 @@ fn sync_heap_files_after_coalesced_flush(
         }
         let lock_t0 = Instant::now();
         pm.lock()
-            .map_err(|_| DbError::database("table page manager lock poisoned"))?
             .sync_heap_file()
             .map_err(|e| DbError::database(e.to_string()))?;
         let _ = lock_t0;
@@ -357,7 +354,7 @@ fn sync_heap_files_after_coalesced_flush(
     Ok(fsync_t0.elapsed().as_micros() as u64)
 }
 
-fn coalesced_flush_page_managers(pms: Vec<Arc<Mutex<PageManager>>>) -> DbResult<(usize, u64, u64)> {
+fn coalesced_flush_page_managers(pms: Vec<Arc<PageManagerMutex>>) -> DbResult<(usize, u64, u64)> {
     if pms.is_empty() {
         return Ok((0, 0, 0));
     }
@@ -411,14 +408,14 @@ pub(crate) fn flush_page_managers_for_tables(
         .lock()
         .map_err(|_| DbError::database("table pm map lock poisoned"))?;
     let table_map_lock_us = map_t0.elapsed().as_micros() as u64;
-    let mut pms: Vec<Arc<Mutex<PageManager>>> = Vec::with_capacity(sorted.len());
+    let mut pms: Vec<Arc<PageManagerMutex>> = Vec::with_capacity(sorted.len());
     let mut pm_lock_wait_us = 0u64;
     for name in &sorted {
         let Some(pm) = map.get(name) else {
             continue;
         };
         let lock_t0 = Instant::now();
-        let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
+        let dirty = pm.lock().dirty_page_count() > 0;
         pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
         if dirty {
             pms.push(pm.clone());
@@ -440,22 +437,22 @@ pub(crate) fn flush_page_managers_for_tables(
 ///
 /// Skips managers with no dirty pages. `CommitFlushPhaseUs::table_map_lock_us` is always zero.
 pub(crate) fn flush_page_managers_cached(
-    pms: &[Arc<Mutex<PageManager>>],
+    pms: &[Arc<PageManagerMutex>],
 ) -> DbResult<(usize, CommitFlushPhaseUs)> {
     if pms.is_empty() {
         return Ok((0, CommitFlushPhaseUs::default()));
     }
-    let mut dirty_pms: Vec<Arc<Mutex<PageManager>>> = Vec::new();
+    let mut dirty_pms: Vec<Arc<PageManagerMutex>> = Vec::new();
     let mut pm_lock_wait_us = 0u64;
     for pm in pms {
         let lock_t0 = Instant::now();
-        let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
+        let dirty = pm.lock().dirty_page_count() > 0;
         pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
         if dirty {
             dirty_pms.push(pm.clone());
         }
     }
-    dirty_pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
+    dirty_pms.sort_by_key(|pm| pm.lock().file_id());
     let (flushed, flush_pm_wait, heap_fsync_us) = coalesced_flush_page_managers(dirty_pms)?;
     Ok((
         flushed,
@@ -470,7 +467,7 @@ pub(crate) fn flush_page_managers_cached(
 pub(crate) fn flush_all_page_managers(
     state: &crate::network::sql_engine::SqlEngineState,
 ) -> DbResult<usize> {
-    let mut pms: Vec<Arc<Mutex<PageManager>>> = Vec::new();
+    let mut pms: Vec<Arc<PageManagerMutex>> = Vec::new();
     pms.push(state.default_page_manager.clone());
     let map = state
         .table_page_managers
@@ -514,13 +511,10 @@ pub fn replay_wal_into_engine(
     // Applying every record to every page manager relies on filtering inside PageManager and
     // becomes incorrect if multiple managers reference the same file_id (which can happen during
     // open + catalog/table PM wiring).
-    let mut pm_by_file_id: HashMap<u32, Arc<Mutex<PageManager>>> = HashMap::new();
+    let mut pm_by_file_id: HashMap<u32, Arc<PageManagerMutex>> = HashMap::new();
     {
         let default = state.default_page_manager.clone();
-        let fid = default
-            .lock()
-            .map_err(|_| DbError::database("page manager lock poisoned"))?
-            .file_id();
+        let fid = default.lock().file_id();
         pm_by_file_id.insert(fid, default);
     }
     {
@@ -529,10 +523,7 @@ pub fn replay_wal_into_engine(
             .lock()
             .map_err(|_| DbError::database("table pm map lock poisoned"))?;
         for (_name, pm) in map.iter() {
-            let fid = pm
-                .lock()
-                .map_err(|_| DbError::database("table page manager lock poisoned"))?
-                .file_id();
+            let fid = pm.lock().file_id();
             pm_by_file_id.entry(fid).or_insert_with(|| pm.clone());
         }
     }
@@ -550,9 +541,7 @@ pub fn replay_wal_into_engine(
         for r in &redo {
             if let Some(fid) = record_file_id(r) {
                 if let Some(pm) = pm_by_file_id.get(&fid) {
-                    let mut g = pm
-                        .lock()
-                        .map_err(|_| DbError::database("page manager lock poisoned"))?;
+                    let mut g = pm.lock();
                     let _ = g.apply_log_record_recovery(r, true);
                 }
             }
@@ -572,9 +561,7 @@ pub fn replay_wal_into_engine(
             }
             if let Some(fid) = record_file_id(r) {
                 if let Some(pm) = pm_by_file_id.get(&fid) {
-                    let mut g = pm
-                        .lock()
-                        .map_err(|_| DbError::database("page manager lock poisoned"))?;
+                    let mut g = pm.lock();
                     let _ = g.apply_log_record_recovery(r, false);
                 }
             }
@@ -701,16 +688,16 @@ mod tests {
 
         let pm_clean = table_page_manager(state, "t_clean").unwrap();
         let pm_dirty = table_page_manager(state, "t_dirty").unwrap();
-        assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);
-        assert!(pm_dirty.lock().unwrap().dirty_page_count() > 0);
+        assert_eq!(pm_clean.lock().dirty_page_count(), 0);
+        assert!(pm_dirty.lock().dirty_page_count() > 0);
 
         let mut tables = HashSet::new();
         tables.insert("t_clean".to_string());
         tables.insert("t_dirty".to_string());
         let (flushed, _metrics) = flush_page_managers_for_tables(state, &tables).unwrap();
         assert!(flushed > 0);
-        assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);
-        assert_eq!(pm_dirty.lock().unwrap().dirty_page_count(), 0);
+        assert_eq!(pm_clean.lock().dirty_page_count(), 0);
+        assert_eq!(pm_dirty.lock().dirty_page_count(), 0);
 
         eng.execute_sql("COMMIT", &mut ctx).unwrap();
     }
@@ -741,15 +728,15 @@ mod tests {
 
         let pm_clean = table_page_manager(state, "t_clean").unwrap();
         let pm_dirty = table_page_manager(state, "t_dirty").unwrap();
-        assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);
-        assert!(pm_dirty.lock().unwrap().dirty_page_count() > 0);
+        assert_eq!(pm_clean.lock().dirty_page_count(), 0);
+        assert!(pm_dirty.lock().dirty_page_count() > 0);
 
         let pms = vec![pm_clean.clone(), pm_dirty.clone()];
         let (flushed, phases) = flush_page_managers_cached(&pms).unwrap();
         assert!(flushed > 0);
         assert_eq!(phases.table_map_lock_us, 0);
-        assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);
-        assert_eq!(pm_dirty.lock().unwrap().dirty_page_count(), 0);
+        assert_eq!(pm_clean.lock().dirty_page_count(), 0);
+        assert_eq!(pm_dirty.lock().dirty_page_count(), 0);
 
         eng.execute_sql("COMMIT", &mut ctx).unwrap();
     }

--- a/src/storage/page_manager.rs
+++ b/src/storage/page_manager.rs
@@ -19,7 +19,10 @@ use crate::storage::{
     page::Page,
 };
 use dashmap::DashMap;
-use parking_lot::RwLock;
+use parking_lot::{Mutex as ParkingMutex, RwLock};
+
+/// Hot-path lock for [`PageManager`] in the network SQL engine.
+pub type PageManagerMutex = ParkingMutex<PageManager>;
 use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -1084,7 +1087,7 @@ impl PageManager {
 /// Spawns a background task that flushes dirty pages every `interval_ms` ms.
 /// Use when `defer_data_flush` is true. Returns a handle to abort the task when done.
 pub fn spawn_deferred_flush_task(
-    pm: Arc<Mutex<PageManager>>,
+    pm: Arc<PageManagerMutex>,
     interval_ms: u64,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
@@ -1092,9 +1095,8 @@ pub fn spawn_deferred_flush_task(
             tokio::time::interval(tokio::time::Duration::from_millis(interval_ms.max(1)));
         loop {
             interval.tick().await;
-            if let Ok(mut guard) = pm.lock() {
-                let _ = guard.flush_dirty_pages();
-            }
+            let mut guard = pm.lock();
+            let _ = guard.flush_dirty_pages();
         }
     })
 }


### PR DESCRIPTION
## Summary

- **Recommendation #2** — `parking_lot::Mutex` for [`PageManager`] on the SQL engine hot path (`PageManagerMutex` type alias).
- Replaces `Arc<std::sync::Mutex<PageManager>>` in `sql_engine`, `sql_engine_wal`, `engine::SessionContext`, and `ScanOperatorFactory` (shared handles with the engine).

## How to interpret TPC-C CI

Compare **RustDB txns_per_s vs PostgreSQL** ratio to **main ~60.3%**. Focus on:

- `commit_pm_lock_wait_us` (expect lower p50/p99 if lock overhead drops)
- `new_order` `commit_flush_us`, overall ratio
- `insert_order_line` / DML phases on native path

## Acceptance

Informational — compare ratio and `commit_pm_lock_wait_us`; no merge gate.

## Test plan

- [ ] CI `bench_tpcc_throughput` on branch `tpcc-exp-pr2-parking-lot-mutex`
- [ ] Compare ratio vs main; check phase log for `commit_pm_lock_wait_us`
