### PR TITLE
perf(tpcc): exp — WAL group commit batch fsync

### DIFF
--- a/scripts/tpcc_throughput_ci.sh
+++ b/scripts/tpcc_throughput_ci.sh
@@ -20,7 +20,8 @@
 #   RUSTDB_GROUP_COMMIT_ENABLED=1 — WAL group commit (default on when unset in engine)
 #   RUSTDB_GROUP_COMMIT_INTERVAL_MS — group commit timer (default 1 ms in container;
 #     run-20 A/B: GROUP_COMMIT_INTERVAL_MS=2 may reduce WAL fsync pressure vs 1 ms)
-#   RUSTDB_GROUP_COMMIT_MAX_BATCH — max records per group commit batch (default 10)
+#   RUSTDB_GROUP_COMMIT_MAX_BATCH / RUSTDB_GROUP_COMMIT_COUNT — max records per group commit batch
+#   RUSTDB_WAL_SYNC_MODE=batch — group-commit fsync batching (SyncLevel::Batch; safe prod default unchanged)
 #   RUSTDB_SQL_WORKER_COUNT — QUIC connection SQL worker threads (default 16; try 32 via workflow_dispatch)
 #   RUSTDB_TPCC_DEFER_INDEX_SYNC=1 — batch secondary-index updates at COMMIT (native TPC-C)
 #   Commit phase log fields (RUSTDB_SQL_PHASE_LOG=1): commit_table_map_lock_us,
@@ -97,7 +98,8 @@ docker run -d --name "$CONTAINER_NAME" \
   -e RUSTDB_SQL_PHASE_LOG="${RUSTDB_SQL_PHASE_LOG:-1}" \
   -e RUSTDB_GROUP_COMMIT_ENABLED="${RUSTDB_GROUP_COMMIT_ENABLED:-1}" \
   -e RUSTDB_GROUP_COMMIT_INTERVAL_MS="${RUSTDB_GROUP_COMMIT_INTERVAL_MS:-1}" \
-  -e RUSTDB_GROUP_COMMIT_MAX_BATCH="${RUSTDB_GROUP_COMMIT_MAX_BATCH:-32}" \
+  -e RUSTDB_GROUP_COMMIT_MAX_BATCH="${RUSTDB_GROUP_COMMIT_MAX_BATCH:-${RUSTDB_GROUP_COMMIT_COUNT:-64}}" \
+  -e RUSTDB_WAL_SYNC_MODE="${RUSTDB_WAL_SYNC_MODE:-batch}" \
   -e RUSTDB_TPCC_DEFER_INDEX_SYNC="${RUSTDB_TPCC_DEFER_INDEX_SYNC:-1}" \
   ${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML:+-e "RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML=${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML}"} \
   -e RUSTDB_BENCH_DEFER_HEAP_FSYNC="${RUSTDB_BENCH_DEFER_HEAP_FSYNC:-1}" \

--- a/src/logging/log_writer.rs
+++ b/src/logging/log_writer.rs
@@ -62,6 +62,8 @@ pub enum SyncLevel {
     Periodic,
     /// Sync after each commit
     OnCommit,
+    /// Group-commit batch: one fsync per interval / max-batch (TPC-C bench preset)
+    Batch,
     /// Sync after every write (slow but safest)
     Always,
 }
@@ -87,6 +89,20 @@ impl LogWriterConfig {
         c.force_flush_immediately = true;
         c.synchronous_commit = true;
         c.group_commit_enabled = false;
+        c.sync_level = SyncLevel::OnCommit;
+        c
+    }
+
+    /// WAL group commit for throughput benchmarks: durable commits batched by interval/count.
+    pub fn batch_group_commit(log_directory: PathBuf) -> Self {
+        let mut c = Self::default();
+        c.log_directory = log_directory;
+        c.sync_level = SyncLevel::Batch;
+        c.force_flush_immediately = false;
+        c.synchronous_commit = true;
+        c.group_commit_enabled = true;
+        c.group_commit_interval_ms = 2;
+        c.group_commit_max_batch = 64;
         c
     }
 }
@@ -724,7 +740,7 @@ impl LogWriter {
             record: record.clone(),
             response_tx: Some(response_tx),
             force_sync: self.config.synchronous_commit,
-            force_flush_immediately: true,
+            force_flush_immediately: self.config.force_flush_immediately,
         };
 
         self.write_tx

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -6,7 +6,7 @@ use crate::logging::checkpoint::{CheckpointConfig, CheckpointManager, DirtyPageF
 use crate::logging::log_record::{
     IsolationLevel as LogIsolationLevel, LogOperationData, LogRecord, LogRecordType, TransactionId,
 };
-use crate::logging::log_writer::{LogWriter, LogWriterConfig};
+use crate::logging::log_writer::{LogWriter, LogWriterConfig, SyncLevel};
 use crate::logging::recovery::{RecoveryConfig, RecoveryManager};
 use crate::network::engine::{engine_error_code, EngineError, SqlIsolationLevel, SqlTransaction};
 use crate::storage::page_manager::PageManager;
@@ -43,10 +43,19 @@ impl SqlEngineWal {
                 cfg.group_commit_interval_ms = ms.max(1);
             }
         }
-        if let Ok(v) = std::env::var("RUSTDB_GROUP_COMMIT_MAX_BATCH") {
+        if let Ok(v) = std::env::var("RUSTDB_GROUP_COMMIT_MAX_BATCH")
+            .or_else(|_| std::env::var("RUSTDB_GROUP_COMMIT_COUNT"))
+        {
             if let Ok(n) = v.parse::<usize>() {
                 cfg.group_commit_max_batch = n.max(1);
             }
+        }
+        let wal_sync_mode = std::env::var("RUSTDB_WAL_SYNC_MODE").ok();
+        if wal_sync_mode.as_deref() == Some("batch") {
+            cfg.sync_level = SyncLevel::Batch;
+            cfg.force_flush_immediately = false;
+            cfg.group_commit_enabled = true;
+            cfg.synchronous_commit = true;
         }
         cfg.force_flush_immediately = std::env::var("RUSTDB_FORCE_FLUSH_IMMEDIATELY")
             .ok()


### PR DESCRIPTION
## Summary

- **Recommendation #3** — WAL group commit: `SyncLevel::Batch`, batched COMMIT fsync via interval + max batch.
- `write_log_durable` respects `force_flush_immediately` so group commit can batch (was always immediate).
- Env: `RUSTDB_WAL_SYNC_MODE=batch`, `RUSTDB_GROUP_COMMIT_INTERVAL_MS`, `RUSTDB_GROUP_COMMIT_MAX_BATCH` / `RUSTDB_GROUP_COMMIT_COUNT`.
- TPC-C CI script enables batch mode by default on this branch.

## How to interpret TPC-C CI

Compare ratio vs **main ~60.3%**. Watch WAL-related commit latency (`commit_us`, `new_order` p50) and overall ratio. Safe prod default (`force_flush_immediately` / per-commit fsync) unchanged unless env sets batch mode.

## Acceptance

Informational — ratio + `new_order` commit phases; revert if success rate drops.

## Test plan

- [ ] `bench_tpcc_throughput` on `tpcc-exp-pr3-group-commit-wal`
- [ ] Compare ratio vs main
