### PR TITLE
perf(tpcc): exp — mimalloc global allocator (CI A/B)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1005,6 +1005,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d1eacfa31c33ec25e873c136ba5669f00f9866d0688bea7be4d3f7e43067df6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1103,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3627c4272df786b9260cabaa46aec1d59c93ede723d4c3ef646c503816b0640"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -1644,6 +1662,7 @@ dependencies = [
  "loom",
  "lz4_flex",
  "memmap2",
+ "mimalloc",
  "parking_lot",
  "postcard",
  "quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ memmap2 = "0.9"
 crossbeam = "0.8"
 dashmap = "6.1"
 parking_lot = "0.12"
+mimalloc = { version = "0.1", optional = true }
 
 # Data compression
 lz4_flex = "0.13"
@@ -94,6 +95,7 @@ criterion = { version = "0.8", optional = true }
 default = []
 criterion = ["dep:criterion"]
 io-uring = ["dep:io-uring"]
+mimalloc-allocator = ["dep:mimalloc"]
 
 # io_uring is Linux-only (supported platform is Linux).
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY benches ./benches
 
-RUN cargo build --release --bin rustdb
+# mimalloc global allocator A/B (PR5); override with plain build on main if needed.
+RUN cargo build --release --bin rustdb --features mimalloc-allocator
 
 # Profiling image (Linux perf + cargo flamegraph).
 # Usage:

--- a/scripts/tpcc_throughput_ci.sh
+++ b/scripts/tpcc_throughput_ci.sh
@@ -26,6 +26,9 @@
 #   Commit phase log fields (RUSTDB_SQL_PHASE_LOG=1): commit_table_map_lock_us,
 #     commit_pm_lock_wait_us, commit_heap_fsync_us, tpcc_kind on sql.commit / sql.execute_tpcc.commit
 #
+# Server image for this branch is built with `--features mimalloc-allocator` (global MiMalloc).
+# Prod/default builds omit it; no runtime env toggle — allocator is compile-time.
+#
 # Client (rustdb_tpcc on host):
 #   RUSTDB_TPCC_NATIVE=1 — pass --native-tpcc (ExecuteTpcc wire path, one RTT per txn;
 #     engine fast path: direct index/heap ops + single COMMIT, not 7× SQL per new_order)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,10 @@
 #![allow(unused_comparisons)]
 #![allow(unused_must_use)]
 
+#[cfg(feature = "mimalloc-allocator")]
+#[global_allocator]
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
 pub mod analyzer;
 pub mod catalog;
 pub mod cli;


### PR DESCRIPTION
## Summary

- **Recommendation #5** — global **mimalloc** allocator A/B via Cargo feature `mimalloc-allocator`.
- `#[global_allocator]` in `lib.rs` when feature enabled; CI Docker image builds with `--features mimalloc-allocator`.
- Prod/default builds on `main` keep the system allocator unless this feature is enabled.

## How to interpret TPC-C CI

Compare ratio vs **main ~60.3%**. Allocator changes affect all paths — look at overall `txns_per_s`, `new_order` latency, and heap-heavy phases (`insert_order_line`, `commit_flush`).

## Enable

- **CI / Docker:** image built with `cargo build --release --features mimalloc-allocator` (this branch).
- **Local:** `cargo build --release --features mimalloc-allocator`
- Note: `RUSTDB_GLOBAL_ALLOC=mimalloc` is documentary only — allocator is compile-time.

## Acceptance

Informational A/B — ratio and txn latency; no merge gate.

## Test plan

- [ ] `bench_tpcc_throughput` on `tpcc-exp-pr5-mimalloc-allocator`
