### PR TITLE
perf(tpcc): arch PR6 — bumpalo/bytes DML for order_line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1632,6 +1632,8 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode-next",
+ "bumpalo",
+ "bytes",
  "clap",
  "criterion",
  "crossbeam",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,8 @@ memmap2 = "0.9"
 crossbeam = "0.8"
 dashmap = "6.1"
 parking_lot = "0.12"
+bumpalo = "3.19"
+bytes = "1.10"
 
 # Data compression
 lz4_flex = "0.13"

--- a/scripts/tpcc_throughput_ci.sh
+++ b/scripts/tpcc_throughput_ci.sh
@@ -23,6 +23,7 @@
 #   RUSTDB_GROUP_COMMIT_MAX_BATCH — max records per group commit batch (default 10)
 #   RUSTDB_SQL_WORKER_COUNT — QUIC connection SQL worker threads (default 16; try 32 via workflow_dispatch)
 #   RUSTDB_TPCC_DEFER_INDEX_SYNC=1 — batch secondary-index updates at COMMIT (native TPC-C)
+#   RUSTDB_TPCC_BUMP_ARENA=1 — bumpalo arena for native order_line row bytes (PR4 experiment)
 #   Commit phase log fields (RUSTDB_SQL_PHASE_LOG=1): commit_table_map_lock_us,
 #     commit_pm_lock_wait_us, commit_heap_fsync_us, tpcc_kind on sql.commit / sql.execute_tpcc.commit
 #
@@ -99,6 +100,7 @@ docker run -d --name "$CONTAINER_NAME" \
   -e RUSTDB_GROUP_COMMIT_INTERVAL_MS="${RUSTDB_GROUP_COMMIT_INTERVAL_MS:-1}" \
   -e RUSTDB_GROUP_COMMIT_MAX_BATCH="${RUSTDB_GROUP_COMMIT_MAX_BATCH:-32}" \
   -e RUSTDB_TPCC_DEFER_INDEX_SYNC="${RUSTDB_TPCC_DEFER_INDEX_SYNC:-1}" \
+  -e RUSTDB_TPCC_BUMP_ARENA="${RUSTDB_TPCC_BUMP_ARENA:-1}" \
   ${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML:+-e "RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML=${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML}"} \
   -e RUSTDB_BENCH_DEFER_HEAP_FSYNC="${RUSTDB_BENCH_DEFER_HEAP_FSYNC:-1}" \
   ${RUSTDB_SQL_WORKER_COUNT:+-e "RUSTDB_SQL_WORKER_COUNT=${RUSTDB_SQL_WORKER_COUNT}"} \

--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -32,6 +32,7 @@ pub mod engine_error_code {
 
 use crate::common::types::RecordId;
 use crate::storage::page_manager::PageManager;
+use bytes::BytesMut;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
@@ -146,7 +147,9 @@ pub struct SessionContext {
     /// Set when native `new_order` DML finishes (before `COMMIT`) for `pre_commit_us`.
     pub(crate) tpcc_dml_done_at: Option<std::time::Instant>,
     /// Reused row serialization buffer for native TPC-C inserts in a transaction.
-    pub(crate) tpcc_row_bytes_buf: Vec<u8>,
+    pub(crate) tpcc_row_bytes_buf: BytesMut,
+    /// Optional per-txn bump arena for hot `order_line` inserts (see `tpcc_bump_arena_enabled`).
+    pub(crate) tpcc_bump: Option<bumpalo::Bump>,
     /// Per-transaction page managers (avoids `table_page_managers` map lock on hot DML/COMMIT).
     pub(crate) txn_pm_cache: HashMap<String, Arc<Mutex<PageManager>>>,
     /// Reused buffer for deferred index column maps (native TPC-C inserts).
@@ -181,7 +184,8 @@ impl Default for SessionContext {
             skip_dml_storage_lock: false,
             tpcc_kind: None,
             tpcc_dml_done_at: None,
-            tpcc_row_bytes_buf: Vec::new(),
+            tpcc_row_bytes_buf: BytesMut::new(),
+            tpcc_bump: None,
             txn_pm_cache: HashMap::new(),
             tpcc_index_column_map_buf: HashMap::new(),
             last_commit_flush_phases: None,

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -650,6 +650,18 @@ pub(crate) fn tpcc_defer_index_sync_enabled() -> bool {
     }
 }
 
+/// When set (non-`0`), native TPC-C keeps a [`bumpalo::Bump`] per open transaction for `order_line` row bytes.
+pub(crate) fn tpcc_bump_arena_enabled() -> bool {
+    std::env::var_os("RUSTDB_TPCC_BUMP_ARENA")
+        .is_some_and(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+}
+
+fn ensure_tpcc_bump_arena(ctx: &mut SessionContext) {
+    if tpcc_bump_arena_enabled() && ctx.tpcc_bump.is_none() {
+        ctx.tpcc_bump = Some(bumpalo::Bump::new());
+    }
+}
+
 /// TPC-C heap insert without constraint-runtime work (seed tables have no PK/FK).
 pub(crate) fn insert_row_tuple_tpcc(
     state: &SqlEngineState,
@@ -684,14 +696,26 @@ pub(crate) fn insert_row_tuple_tpcc_deferred(
         });
     }
     record_touched_table(ctx, table);
+    if table == "order_line" {
+        ensure_tpcc_bump_arena(ctx);
+    }
     let row_bytes = tuple.to_bytes().map_err(map_db_err)?;
+    let row_slice: &[u8] = if table == "order_line" {
+        if let Some(ref bump) = ctx.tpcc_bump {
+            bump.alloc_slice_copy(&row_bytes)
+        } else {
+            &row_bytes
+        }
+    } else {
+        &row_bytes
+    };
     ctx.tpcc_row_bytes_buf.clear();
-    ctx.tpcc_row_bytes_buf.extend_from_slice(&row_bytes);
+    ctx.tpcc_row_bytes_buf.extend_from_slice(row_slice);
     let pm_for_table = table_page_manager_cached(state, ctx, table)?;
     let mut pm = pm_for_table.lock().map_err(|_| lock_poisoned_engine())?;
     let ins = pm.insert(&ctx.tpcc_row_bytes_buf).map_err(map_db_err)?;
     maybe_simulate_dml_crash("insert_row");
-    let mut payload = std::mem::take(&mut ctx.tpcc_row_bytes_buf);
+    let payload = row_bytes;
     let wal_clock = state.wal.is_some().then(Instant::now);
     if let Some(tx) = ctx.transaction.as_mut() {
         if let Some(ref wal) = state.wal {
@@ -3119,6 +3143,7 @@ pub(crate) fn tpcc_run_in_transaction(
     ctx.tpcc_dml_done_at = None;
     ctx.last_commit_flush_phases = None;
     ctx.tpcc_row_bytes_buf.clear();
+    ctx.tpcc_bump = None;
     ctx.txn_pm_cache.clear();
     ctx.tpcc_index_column_map_buf.clear();
     begin_transaction(state, ctx)?;


### PR DESCRIPTION
## Summary

- **PR6 (DML tail)** — Reuse `bytes::BytesMut` for native TPC-C row serialization; optional `bumpalo::Bump` per transaction for hot `order_line` inserts in `insert_row_tuple_tpcc_deferred`.
- WAL/undo share one `row_bytes` allocation (avoids `mem::take` on the insert buffer).
- CI: optional `RUSTDB_TPCC_BUMP_ARENA=1` in `tpcc_throughput_ci.sh` (default on in container).

Cherry-picked from closed #76 (`tpcc-exp-pr4-bumpalo-bytes-dml`).

## Acceptance

- `insert_order_line_us` p50 ≤ 32 ms; ratio +0…+2 p.p. vs main (~60.3%).
- Guardrail: full-mix ratio ≥ 58%, `payment` commit_flush p50 < 10 ms, success 100%.

## Test plan

- [x] `cargo fmt`, `cargo clippy -D warnings`, `cargo test --lib` (879 passed locally)
- [ ] `bench_tpcc_throughput` on `tpcc-arch-pr6-dml-order-line`
