### PR TITLE
perf(tpcc): arch PR1 — WAL-first COMMIT (bench defer heap flush)

### DIFF
--- a/scripts/tpcc_throughput_ci.sh
+++ b/scripts/tpcc_throughput_ci.sh
@@ -15,7 +15,9 @@
 #   RUSTDB_SQL_PHASE_LOG=1 — rustdb::sql_phases tracing (parse/update/delete timings)
 #   RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML=1 — skip flush_dirty_pages after DML when WAL is on;
 #     explicit COMMIT still writes/fsyncs commits.log per durability (independent of defer)
-#   RUSTDB_BENCH_DEFER_HEAP_FSYNC=1 — on COMMIT, write dirty heap pages but skip per-table fsync
+#   RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT=1 — skip synchronous heap flush on explicit COMMIT (WAL on);
+#     bench/CI only; production default still flushes on COMMIT. WAL + commits.log remain durable.
+#   RUSTDB_BENCH_DEFER_HEAP_FSYNC=1 — when heap flush runs, write dirty pages but skip per-table fsync
 #     (throughput CI only; WAL + commits.log remain the durability path for the job)
 #   RUSTDB_GROUP_COMMIT_ENABLED=1 — WAL group commit (default on when unset in engine)
 #   RUSTDB_GROUP_COMMIT_INTERVAL_MS — group commit timer (default 1 ms in container;
@@ -100,6 +102,7 @@ docker run -d --name "$CONTAINER_NAME" \
   -e RUSTDB_GROUP_COMMIT_MAX_BATCH="${RUSTDB_GROUP_COMMIT_MAX_BATCH:-32}" \
   -e RUSTDB_TPCC_DEFER_INDEX_SYNC="${RUSTDB_TPCC_DEFER_INDEX_SYNC:-1}" \
   ${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML:+-e "RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML=${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML}"} \
+  -e RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT="${RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT:-1}" \
   -e RUSTDB_BENCH_DEFER_HEAP_FSYNC="${RUSTDB_BENCH_DEFER_HEAP_FSYNC:-1}" \
   ${RUSTDB_SQL_WORKER_COUNT:+-e "RUSTDB_SQL_WORKER_COUNT=${RUSTDB_SQL_WORKER_COUNT}"} \
   -e RUST_LOG="${RUST_LOG:-info}" \

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -27,6 +27,9 @@
 //!   `COMMIT`). Explicit `BEGIN … COMMIT` transactions defer per-statement heap flush and flush only
 //!   heap page managers for tables touched by DML on `COMMIT` / `ROLLBACK` (see
 //!   `SqlTransaction::touched_tables`).
+//! - Bench-only (**`RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT=1`**, WAL on): skip synchronous heap flush on
+//!   explicit `COMMIT` and on `ROLLBACK` without undo (`scripts/tpcc_throughput_ci.sh`). WAL and
+//!   `commits.log` remain the CI durability path; checkpoint and `ROLLBACK` with undo still flush.
 //! - WAL group commit knobs: `RUSTDB_GROUP_COMMIT_ENABLED`, `RUSTDB_GROUP_COMMIT_INTERVAL_MS`,
 //!   `RUSTDB_GROUP_COMMIT_MAX_BATCH`, `RUSTDB_FORCE_FLUSH_IMMEDIATELY` (see `crate::network::sql_engine_wal`).
 //! - Implicit auto-commit DML still flushes after each statement by default so standalone heap files
@@ -1283,8 +1286,16 @@ fn commit_transaction(
     let touched: HashSet<String> = std::mem::take(&mut tx.touched_tables);
     let flush_tables_count = touched.len();
     span.record("flush_tables_count", flush_tables_count);
+    let skip_heap_flush =
+        state.wal.is_some() && !crate::network::sql_engine_wal::heap_flush_on_commit_enabled();
+    let commit_heap_flush_skipped = u8::from(skip_heap_flush);
     let flush_clock = Instant::now();
-    let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
+    let (_flushed_pages, flush_phases) = if skip_heap_flush {
+        (
+            0,
+            crate::network::sql_engine_wal::CommitFlushPhaseUs::default(),
+        )
+    } else if !ctx.txn_pm_cache.is_empty() {
         let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
         pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
         crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
@@ -1326,6 +1337,7 @@ fn commit_transaction(
             touched_table_count,
             pending_index_count,
             commit_log_fsync,
+            commit_heap_flush_skipped,
             "sql.commit"
         );
     }
@@ -1375,7 +1387,12 @@ fn rollback_transaction(
     }
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
-    let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
+    let skip_heap_flush = state.wal.is_some()
+        && !crate::network::sql_engine_wal::heap_flush_on_commit_enabled()
+        && !had_undo;
+    let _ = if skip_heap_flush {
+        Ok(0)
+    } else if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
         let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
             .iter()
             .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
@@ -4969,6 +4986,31 @@ mod tests {
             dirty_after_commit, 0,
             "COMMIT should flush dirty heap pages"
         );
+    }
+
+    #[test]
+    fn explicit_transaction_defers_heap_flush_on_commit_when_env_set() {
+        std::env::set_var("RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT", "1");
+        let dir = TempDir::new().unwrap();
+        let eng = SqlEngine::open(dir.path().to_path_buf()).unwrap();
+        assert!(eng.wal_enabled());
+        let mut ctx = SessionContext::default();
+        eng.execute_sql(
+            "CREATE TABLE defer_commit_flush (k INT PRIMARY KEY)",
+            &mut ctx,
+        )
+        .unwrap();
+        eng.execute_sql("BEGIN TRANSACTION", &mut ctx).unwrap();
+        eng.execute_sql("INSERT INTO defer_commit_flush (k) VALUES (1)", &mut ctx)
+            .unwrap();
+        let pm = table_page_manager(eng.state_for_test(), "defer_commit_flush").unwrap();
+        assert!(pm.lock().unwrap().dirty_page_count() > 0);
+        eng.execute_sql("COMMIT", &mut ctx).unwrap();
+        assert!(
+            pm.lock().unwrap().dirty_page_count() > 0,
+            "COMMIT should skip heap flush when RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT=1"
+        );
+        std::env::remove_var("RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT");
     }
 
     #[test]

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -311,6 +311,15 @@ pub(crate) fn bench_defer_heap_fsync_enabled() -> bool {
     std::env::var_os("RUSTDB_BENCH_DEFER_HEAP_FSYNC").is_some_and(|v| v != "0")
 }
 
+/// Whether explicit `COMMIT` / no-op `ROLLBACK` should synchronously flush dirty heap pages.
+///
+/// When **`RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT=1`** (bench/CI only; see `scripts/tpcc_throughput_ci.sh`),
+/// returns `false` so callers skip `flush_page_managers_*` while WAL is enabled. Checkpoint and
+/// `ROLLBACK` with undo still flush regardless of this flag.
+pub(crate) fn heap_flush_on_commit_enabled() -> bool {
+    std::env::var_os("RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT").is_none_or(|v| v == "0")
+}
+
 /// Microsecond breakdown for `COMMIT` heap flush (logged on `rustdb::sql_phases`).
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct CommitFlushPhaseUs {
@@ -681,6 +690,17 @@ mod tests {
         std::env::set_var("RUSTDB_BENCH_DEFER_HEAP_FSYNC", "0");
         assert!(!bench_defer_heap_fsync_enabled());
         std::env::remove_var("RUSTDB_BENCH_DEFER_HEAP_FSYNC");
+    }
+
+    #[test]
+    fn heap_flush_on_commit_respects_env() {
+        std::env::remove_var("RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT");
+        assert!(heap_flush_on_commit_enabled());
+        std::env::set_var("RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT", "1");
+        assert!(!heap_flush_on_commit_enabled());
+        std::env::set_var("RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT", "0");
+        assert!(heap_flush_on_commit_enabled());
+        std::env::remove_var("RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add \RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT=1\ for CI/bench only: skip synchronous \lush_page_managers_*\ on explicit COMMIT and no-op ROLLBACK when WAL is on.
- Log \commit_heap_flush_skipped\ in \ustdb::sql_phases\ for summarize.
- Checkpoint and ROLLBACK with undo still flush.

## Test plan
- [x] \cargo clippy -D warnings\
- [x] unit tests: \heap_flush_on_commit_respects_env\, \explicit_transaction_defers_heap_flush_on_commit_when_env_set\
- [ ] CI \ench_tpcc_throughput\ on branch

Made with [Cursor](https://cursor.com)