### PR TITLE
perf(tpcc): arch PR3 — touched+dirty COMMIT flush

### DIFF
--- a/src/network/engine.rs
+++ b/src/network/engine.rs
@@ -148,7 +148,8 @@ pub struct SessionContext {
     /// Reused row serialization buffer for native TPC-C inserts in a transaction.
     pub(crate) tpcc_row_bytes_buf: Vec<u8>,
     /// Per-transaction page managers (avoids `table_page_managers` map lock on hot DML/COMMIT).
-    pub(crate) txn_pm_cache: HashMap<String, Arc<Mutex<PageManager>>>,
+    /// `file_id` at cache insert — COMMIT sorts without re-locking PM.
+    pub(crate) txn_pm_cache: HashMap<String, (u32, Arc<Mutex<PageManager>>)>,
     /// Reused buffer for deferred index column maps (native TPC-C inserts).
     pub(crate) tpcc_index_column_map_buf: HashMap<String, String>,
     /// Last `COMMIT` flush breakdown (native TPC-C gap accounting).

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1284,10 +1284,28 @@ fn commit_transaction(
     let flush_tables_count = touched.len();
     span.record("flush_tables_count", flush_tables_count);
     let flush_clock = Instant::now();
-    let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = ctx.txn_pm_cache.values().cloned().collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map_err(map_db_err)?
+    let (_flushed_pages, flush_phases) = if !ctx.txn_pm_cache.is_empty() && !touched.is_empty() {
+        let (mut flushed, mut flush_phases) =
+            crate::network::sql_engine_wal::flush_touched_txn_page_managers(
+                &ctx.txn_pm_cache,
+                &touched,
+            )
+            .map_err(map_db_err)?;
+        let missing: HashSet<String> = touched
+            .iter()
+            .filter(|t| !ctx.txn_pm_cache.contains_key(*t))
+            .cloned()
+            .collect();
+        if !missing.is_empty() {
+            let (extra, ep) =
+                crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &missing)
+                    .map_err(map_db_err)?;
+            flushed += extra;
+            flush_phases.table_map_lock_us += ep.table_map_lock_us;
+            flush_phases.pm_lock_wait_us += ep.pm_lock_wait_us;
+            flush_phases.heap_fsync_us += ep.heap_fsync_us;
+        }
+        (flushed, flush_phases)
     } else if touched.is_empty() {
         (
             0,
@@ -1376,12 +1394,22 @@ fn rollback_transaction(
     // Persist rollback: otherwise the next process sees heap pages from disk that still contain
     // undone inserts (WAL replay does not redo aborted txs, so durability must match).
     let _ = if !ctx.txn_pm_cache.is_empty() && !flush_tables.is_empty() {
-        let mut pms: Vec<Arc<Mutex<PageManager>>> = flush_tables
+        let (n, _) = crate::network::sql_engine_wal::flush_touched_txn_page_managers(
+            &ctx.txn_pm_cache,
+            &flush_tables,
+        )
+        .map_err(map_db_err)?;
+        let missing: HashSet<String> = flush_tables
             .iter()
-            .filter_map(|t| ctx.txn_pm_cache.get(t).cloned())
+            .filter(|t| !ctx.txn_pm_cache.contains_key(*t))
+            .cloned()
             .collect();
-        pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-        crate::network::sql_engine_wal::flush_page_managers_cached(&pms).map(|(n, _)| n)
+        if missing.is_empty() {
+            Ok(n)
+        } else {
+            crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &missing)
+                .map(|(e, _)| n + e)
+        }
     } else {
         crate::network::sql_engine_wal::flush_page_managers_for_tables(state, &flush_tables)
             .map(|(n, _)| n)
@@ -1540,11 +1568,13 @@ pub(crate) fn table_page_manager_cached(
     ctx: &mut SessionContext,
     table: &str,
 ) -> Result<Arc<Mutex<PageManager>>, EngineError> {
-    if let Some(pm) = ctx.txn_pm_cache.get(table) {
+    if let Some((_, pm)) = ctx.txn_pm_cache.get(table) {
         return Ok(pm.clone());
     }
     let pm = table_page_manager(state, table)?;
-    ctx.txn_pm_cache.insert(table.to_string(), pm.clone());
+    let file_id = pm.lock().map_err(|_| lock_poisoned_engine())?.file_id();
+    ctx.txn_pm_cache
+        .insert(table.to_string(), (file_id, pm.clone()));
     Ok(pm)
 }
 
@@ -4972,6 +5002,25 @@ mod tests {
     }
 
     #[test]
+    fn commit_flushes_only_touched_tables_from_txn_pm_cache() {
+        let dir = TempDir::new().unwrap();
+        let eng = SqlEngine::open(dir.path().to_path_buf()).unwrap();
+        let state = eng.state_for_test();
+        let mut ctx = SessionContext::default();
+        eng.execute_sql("CREATE TABLE ta (k INT PRIMARY KEY)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("CREATE TABLE tb (k INT PRIMARY KEY)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("INSERT INTO tb (k) VALUES (0)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("BEGIN TRANSACTION", &mut ctx).unwrap();
+        let _ = table_page_manager_cached(state, &mut ctx, "tb").unwrap();
+        eng.execute_sql("INSERT INTO ta (k) VALUES (1)", &mut ctx)
+            .unwrap();
+        assert_eq!(ctx.txn_pm_cache.len(), 1);
+        eng.execute_sql("COMMIT", &mut ctx).unwrap();
+    }
+
     fn table_page_manager_cached_reuses_arc_in_transaction() {
         let dir = TempDir::new().unwrap();
         let eng = SqlEngine::open(dir.path().to_path_buf()).unwrap();

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -365,7 +365,9 @@ fn coalesced_flush_page_managers(pms: Vec<Arc<Mutex<PageManager>>>) -> DbResult<
     let mut sync_targets = Vec::new();
     let mut pm_lock_wait_us = 0u64;
 
-    if pms.len() <= 1 {
+    const COALESCED_FLUSH_PARALLEL_MIN: usize = 2;
+
+    if pms.len() < COALESCED_FLUSH_PARALLEL_MIN {
         for pm in pms {
             let (n, file_id, wait) = flush_pm_writes_only(&pm)?;
             pm_lock_wait_us += wait;
@@ -436,33 +438,50 @@ pub(crate) fn flush_page_managers_for_tables(
     ))
 }
 
-/// Flushes dirty pages for the given page managers without acquiring `table_page_managers`.
-///
-/// Skips managers with no dirty pages. `CommitFlushPhaseUs::table_map_lock_us` is always zero.
+/// Flushes dirty heaps for txn-cached `(file_id, pm)` limited to `touched`.
+pub(crate) fn flush_touched_txn_page_managers(
+    cache: &std::collections::HashMap<String, (u32, Arc<Mutex<PageManager>>)>,
+    touched: &std::collections::HashSet<String>,
+) -> DbResult<(usize, CommitFlushPhaseUs)> {
+    if touched.is_empty() {
+        return Ok((0, CommitFlushPhaseUs::default()));
+    }
+    let mut entries: Vec<(u32, Arc<Mutex<PageManager>>)> = Vec::new();
+    for table in touched {
+        if let Some((file_id, pm)) = cache.get(table) {
+            entries.push((*file_id, pm.clone()));
+        }
+    }
+    if entries.is_empty() {
+        return Ok((0, CommitFlushPhaseUs::default()));
+    }
+    entries.sort_by_key(|(f, _)| *f);
+    let (flushed, w, fsync) =
+        coalesced_flush_page_managers(entries.into_iter().map(|(_, p)| p).collect())?;
+    Ok((
+        flushed,
+        CommitFlushPhaseUs {
+            table_map_lock_us: 0,
+            pm_lock_wait_us: w,
+            heap_fsync_us: fsync,
+        },
+    ))
+}
+
+/// One PM lock per heap via [`flush_pm_writes_only`].
 pub(crate) fn flush_page_managers_cached(
     pms: &[Arc<Mutex<PageManager>>],
 ) -> DbResult<(usize, CommitFlushPhaseUs)> {
     if pms.is_empty() {
         return Ok((0, CommitFlushPhaseUs::default()));
     }
-    let mut dirty_pms: Vec<Arc<Mutex<PageManager>>> = Vec::new();
-    let mut pm_lock_wait_us = 0u64;
-    for pm in pms {
-        let lock_t0 = Instant::now();
-        let dirty = pm.lock().map(|g| g.dirty_page_count() > 0).unwrap_or(false);
-        pm_lock_wait_us += lock_t0.elapsed().as_micros() as u64;
-        if dirty {
-            dirty_pms.push(pm.clone());
-        }
-    }
-    dirty_pms.sort_by_key(|pm| pm.lock().map(|g| g.file_id()).unwrap_or(u32::MAX));
-    let (flushed, flush_pm_wait, heap_fsync_us) = coalesced_flush_page_managers(dirty_pms)?;
+    let (flushed, w, fsync) = coalesced_flush_page_managers(pms.to_vec())?;
     Ok((
         flushed,
         CommitFlushPhaseUs {
             table_map_lock_us: 0,
-            pm_lock_wait_us: pm_lock_wait_us.saturating_add(flush_pm_wait),
-            heap_fsync_us,
+            pm_lock_wait_us: w,
+            heap_fsync_us: fsync,
         },
     ))
 }
@@ -751,6 +770,40 @@ mod tests {
         assert_eq!(pm_clean.lock().unwrap().dirty_page_count(), 0);
         assert_eq!(pm_dirty.lock().unwrap().dirty_page_count(), 0);
 
+        eng.execute_sql("COMMIT", &mut ctx).unwrap();
+    }
+
+    #[test]
+    fn flush_touched_txn_page_managers_skips_clean_and_flushes_dirty() {
+        let dir = TempDir::new().unwrap();
+        let eng = SqlEngine::open(dir.path().to_path_buf()).unwrap();
+        let state = eng.state_for_test();
+        let mut ctx = SessionContext::default();
+        eng.execute_sql("CREATE TABLE t_clean (k INT PRIMARY KEY)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("CREATE TABLE t_dirty (k INT PRIMARY KEY)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("INSERT INTO t_clean (k) VALUES (0)", &mut ctx)
+            .unwrap();
+        eng.execute_sql("BEGIN TRANSACTION", &mut ctx).unwrap();
+        eng.execute_sql("INSERT INTO t_dirty (k) VALUES (1)", &mut ctx)
+            .unwrap();
+        let pm_clean = table_page_manager(state, "t_clean").unwrap();
+        let pm_dirty = table_page_manager(state, "t_dirty").unwrap();
+        let mut cache = std::collections::HashMap::new();
+        cache.insert(
+            "t_clean".to_string(),
+            (pm_clean.lock().unwrap().file_id(), pm_clean.clone()),
+        );
+        cache.insert(
+            "t_dirty".to_string(),
+            (pm_dirty.lock().unwrap().file_id(), pm_dirty.clone()),
+        );
+        let mut touched = HashSet::new();
+        touched.insert("t_clean".to_string());
+        touched.insert("t_dirty".to_string());
+        let (flushed, _) = flush_touched_txn_page_managers(&cache, &touched).unwrap();
+        assert!(flushed > 0);
         eng.execute_sql("COMMIT", &mut ctx).unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- \	xn_pm_cache: HashMap<String, (u32, Arc<PageManagerMutex>)>\ — sort by file_id without re-locking.
- Flush only touched ∩ dirty; single-pass dirty check; parallel coalesced flush at len >= 2.

## Test plan
- [x] clippy/tests
- [ ] CI bench_tpcc_throughput

Made with [Cursor](https://cursor.com)