### PR TITLE
perf(tpcc): arch PR5 — batched heap I/O

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY benches ./benches
 
-RUN cargo build --release --bin rustdb
+# io_uring backend (Linux) for TPC-C batched flush experiment (PR1).
+RUN cargo build --release --bin rustdb --features io-uring
 
 # Profiling image (Linux perf + cargo flamegraph).
 # Usage:

--- a/scripts/tpcc_throughput_ci.sh
+++ b/scripts/tpcc_throughput_ci.sh
@@ -21,6 +21,8 @@
 #   RUSTDB_GROUP_COMMIT_INTERVAL_MS — group commit timer (default 1 ms in container;
 #     run-20 A/B: GROUP_COMMIT_INTERVAL_MS=2 may reduce WAL fsync pressure vs 1 ms)
 #   RUSTDB_GROUP_COMMIT_MAX_BATCH — max records per group commit batch (default 10)
+#   RUSTDB_IO_URING_BATCH=1 — batched multi-page dirty flush (linked io_uring when available, else sequential)
+#   RUSTDB_USE_IO_URING=0 — force std::fs I/O (CI Docker often lacks io_uring; auto-fallback otherwise)
 #   RUSTDB_SQL_WORKER_COUNT — QUIC connection SQL worker threads (default 16; try 32 via workflow_dispatch)
 #   RUSTDB_TPCC_DEFER_INDEX_SYNC=1 — batch secondary-index updates at COMMIT (native TPC-C)
 #   Commit phase log fields (RUSTDB_SQL_PHASE_LOG=1): commit_table_map_lock_us,
@@ -101,6 +103,7 @@ docker run -d --name "$CONTAINER_NAME" \
   -e RUSTDB_TPCC_DEFER_INDEX_SYNC="${RUSTDB_TPCC_DEFER_INDEX_SYNC:-1}" \
   ${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML:+-e "RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML=${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML}"} \
   -e RUSTDB_BENCH_DEFER_HEAP_FSYNC="${RUSTDB_BENCH_DEFER_HEAP_FSYNC:-1}" \
+  -e RUSTDB_IO_URING_BATCH="${RUSTDB_IO_URING_BATCH:-1}" \
   ${RUSTDB_SQL_WORKER_COUNT:+-e "RUSTDB_SQL_WORKER_COUNT=${RUSTDB_SQL_WORKER_COUNT}"} \
   -e RUST_LOG="${RUST_LOG:-info}" \
   "$RUSTDB_IMAGE" \

--- a/src/storage/advanced_file_manager.rs
+++ b/src/storage/advanced_file_manager.rs
@@ -178,6 +178,18 @@ impl AdvancedDatabaseFile {
         Ok(())
     }
 
+    /// Writes multiple pages; may use a single linked io_uring submit when enabled.
+    pub fn write_pages_batch(&mut self, pages: &[(PageId, &[u8])]) -> Result<()> {
+        if pages.is_empty() {
+            return Ok(());
+        }
+        self.base_file.write_blocks_batch(pages)?;
+        self.header.increment_write_count();
+        self.statistics.write_operations += pages.len() as u64;
+        self.header_dirty = true;
+        Ok(())
+    }
+
     /// Checks if file pre-extension is needed
     pub fn check_preextension(&mut self) -> Result<bool> {
         let should_extend = self.extension_manager.should_preextend(
@@ -553,6 +565,22 @@ impl AdvancedFileManager {
         Ok(())
     }
 
+    /// Writes multiple pages to one file (batched backend I/O when configured).
+    pub fn write_pages_batch(
+        &mut self,
+        file_id: AdvancedFileId,
+        pages: &[(PageId, &[u8])],
+    ) -> Result<()> {
+        let file = self
+            .advanced_files
+            .get_mut(&file_id)
+            .ok_or_else(|| Error::database(format!("File {} not found", file_id)))?;
+
+        file.write_pages_batch(pages)?;
+        self.update_global_statistics();
+        Ok(())
+    }
+
     /// Synchronizes a file
     pub fn sync_file(&mut self, file_id: AdvancedFileId) -> Result<()> {
         let file = self
@@ -729,6 +757,32 @@ mod tests {
         // Check statistics
         let stats = manager.get_global_statistics();
         assert!(stats.total_pages >= 10);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_pages_batch() -> Result<()> {
+        let temp_dir = TempDir::new()
+            .map_err(|e| Error::database(format!("Failed to create temp dir: {}", e)))?;
+        let mut manager = AdvancedFileManager::new(temp_dir.path())?;
+
+        let file_id = manager.create_database_file(
+            "batch.db",
+            DatabaseFileType::Data,
+            1,
+            ExtensionStrategy::Fixed,
+        )?;
+
+        let page_a = 2;
+        let page_b = 4;
+        let data_a = vec![0xAAu8; crate::storage::database_file::BLOCK_SIZE];
+        let data_b = vec![0xBBu8; crate::storage::database_file::BLOCK_SIZE];
+        manager.write_pages_batch(file_id, &[(page_a, &data_a), (page_b, &data_b)])?;
+        manager.sync_file(file_id)?;
+
+        assert_eq!(manager.read_page(file_id, page_a)?, data_a);
+        assert_eq!(manager.read_page(file_id, page_b)?, data_b);
 
         Ok(())
     }

--- a/src/storage/block_io.rs
+++ b/src/storage/block_io.rs
@@ -7,10 +7,71 @@ use crate::common::{Error, Result};
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
-use std::sync::Mutex;
+use std::sync::{Mutex, Once, OnceLock};
 
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 use std::os::unix::io::AsRawFd;
+
+/// When set (non-`0`), dirty-page flush batches multiple page writes via
+/// [`BlockIoBackend::write_at_batch`] (linked io_uring on Linux when available, else sequential).
+pub fn io_uring_batch_writes_enabled() -> bool {
+    std::env::var_os("RUSTDB_IO_URING_BATCH")
+        .is_some_and(|v| v != "0" && !v.eq_ignore_ascii_case("false"))
+}
+
+#[cfg(all(target_os = "linux", feature = "io-uring"))]
+fn io_uring_disabled_by_env() -> bool {
+    std::env::var_os("RUSTDB_USE_IO_URING")
+        .is_some_and(|v| v == "0" || v.eq_ignore_ascii_case("false"))
+}
+
+#[cfg(all(target_os = "linux", feature = "io-uring"))]
+fn io_uring_ring_error_is_fallback(err: &std::io::Error) -> bool {
+    matches!(
+        err.raw_os_error(),
+        Some(1) | Some(13) | Some(38) | Some(95) // EPERM, EACCES, ENOSYS, ENOTSUP
+    ) || matches!(
+        err.kind(),
+        std::io::ErrorKind::PermissionDenied | std::io::ErrorKind::Unsupported
+    )
+}
+
+#[cfg(all(target_os = "linux", feature = "io-uring"))]
+static IO_URING_PROBE: OnceLock<bool> = OnceLock::new();
+
+#[cfg(all(target_os = "linux", feature = "io-uring"))]
+static IO_URING_FALLBACK_LOG: Once = Once::new();
+
+#[cfg(all(target_os = "linux", feature = "io-uring"))]
+fn io_uring_runtime_available() -> bool {
+    *IO_URING_PROBE.get_or_init(|| {
+        if io_uring_disabled_by_env() {
+            return false;
+        }
+        match io_uring::IoUring::new(IoUringBackend::RING_ENTRIES) {
+            Ok(_) => true,
+            Err(e) if io_uring_ring_error_is_fallback(&e) => {
+                IO_URING_FALLBACK_LOG.call_once(|| {
+                    tracing::warn!(
+                        error = %e,
+                        "io_uring unavailable (e.g. Docker without CAP_SYS_ADMIN); \
+                         using std::fs block I/O — batched flush still uses sequential write_at"
+                    );
+                });
+                false
+            }
+            Err(e) => {
+                IO_URING_FALLBACK_LOG.call_once(|| {
+                    tracing::warn!(
+                        error = %e,
+                        "io_uring probe failed; using std::fs block I/O"
+                    );
+                });
+                false
+            }
+        }
+    })
+}
 
 /// Block I/O backend trait.
 /// Implementations: StdFileBackend (all platforms), IoUringBackend (Linux).
@@ -20,6 +81,14 @@ pub trait BlockIoBackend: Send + Sync {
 
     /// Writes `data` at the given offset.
     fn write_at(&mut self, offset: u64, data: &[u8]) -> Result<()>;
+
+    /// Writes multiple `(offset, payload)` pairs. Default loops [`Self::write_at`].
+    fn write_at_batch(&mut self, writes: &[(u64, &[u8])]) -> Result<()> {
+        for (offset, data) in writes {
+            self.write_at(*offset, data)?;
+        }
+        Ok(())
+    }
 
     /// Synchronizes all data to disk.
     fn sync(&mut self) -> Result<()>;
@@ -64,8 +133,8 @@ impl StdFileBackend {
 }
 
 /// Creates an appropriate I/O backend for the platform.
-/// On Linux with `io-uring` feature: uses IoUringBackend.
-/// Otherwise: uses StdFileBackend.
+/// On Linux with `io-uring` feature: uses `IoUringBackend` when the ring is available,
+/// otherwise [`StdFileBackend`]. Set `RUSTDB_USE_IO_URING=0` to skip io_uring entirely.
 #[allow(clippy::missing_panics_doc)]
 pub fn create_backend_for_file(
     path: &Path,
@@ -74,10 +143,18 @@ pub fn create_backend_for_file(
 ) -> Result<Box<dyn BlockIoBackend>> {
     #[cfg(all(target_os = "linux", feature = "io-uring"))]
     {
+        if io_uring_runtime_available() {
+            return if create {
+                IoUringBackend::create(path).map(|b| Box::new(b) as Box<dyn BlockIoBackend>)
+            } else {
+                IoUringBackend::open(path, read_only)
+                    .map(|b| Box::new(b) as Box<dyn BlockIoBackend>)
+            };
+        }
         if create {
-            Ok(Box::new(IoUringBackend::create(path)?))
+            Ok(Box::new(StdFileBackend::create(path)?))
         } else {
-            Ok(Box::new(IoUringBackend::open(path, read_only)?))
+            Ok(Box::new(StdFileBackend::open(path, read_only)?))
         }
     }
 
@@ -186,6 +263,47 @@ impl IoUringBackend {
             ring: Mutex::new(ring),
         })
     }
+
+    fn write_at_single(&mut self, offset: u64, data: &[u8]) -> Result<()> {
+        let len = data.len();
+        if len == 0 {
+            return Ok(());
+        }
+        let fd = io_uring::types::Fd(self.file.as_raw_fd());
+        let write_e = io_uring::opcode::Write::new(fd, data.as_ptr(), len as u32)
+            .offset(offset)
+            .build()
+            .user_data(0);
+        let mut ring = self
+            .ring
+            .lock()
+            .map_err(|e| Error::database(format!("Lock error: {}", e)))?;
+        unsafe {
+            ring.submission()
+                .push(&write_e)
+                .map_err(|e| Error::database(format!("Failed to push write: {}", e)))?;
+        }
+        ring.submit_and_wait(1)
+            .map_err(|e| Error::database(format!("io_uring submit_and_wait: {}", e)))?;
+        let cqe = ring
+            .completion()
+            .next()
+            .ok_or_else(|| Error::database("io_uring completion queue empty"))?;
+        let res = cqe.result();
+        if res < 0 {
+            return Err(Error::database(format!(
+                "io_uring write failed: {}",
+                std::io::Error::from_raw_os_error(-res)
+            )));
+        }
+        if res as usize != len {
+            return Err(Error::database(format!(
+                "io_uring short write: got {} expected {}",
+                res, len
+            )));
+        }
+        Ok(())
+    }
 }
 
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
@@ -233,42 +351,75 @@ impl BlockIoBackend for IoUringBackend {
     }
 
     fn write_at(&mut self, offset: u64, data: &[u8]) -> Result<()> {
-        let len = data.len();
-        if len == 0 {
+        self.write_at_batch(&[(offset, data)])
+    }
+
+    fn write_at_batch(&mut self, writes: &[(u64, &[u8])]) -> Result<()> {
+        use io_uring::squeue::Flags;
+        let non_empty: Vec<(u64, &[u8])> = writes
+            .iter()
+            .copied()
+            .filter(|(_, data)| !data.is_empty())
+            .collect();
+        if non_empty.is_empty() {
             return Ok(());
         }
+        if !io_uring_batch_writes_enabled() || non_empty.len() == 1 {
+            for (offset, data) in non_empty {
+                self.write_at_single(offset, data)?;
+            }
+            return Ok(());
+        }
+
         let fd = io_uring::types::Fd(self.file.as_raw_fd());
-        let write_e = io_uring::opcode::Write::new(fd, data.as_ptr(), len as u32)
-            .offset(offset)
-            .build()
-            .user_data(0);
         let mut ring = self
             .ring
             .lock()
             .map_err(|e| Error::database(format!("Lock error: {}", e)))?;
-        unsafe {
-            ring.submission()
-                .push(&write_e)
-                .map_err(|e| Error::database(format!("Failed to push write: {}", e)))?;
+        let mut submission = ring.submission();
+        let last = non_empty.len() - 1;
+        for (i, (offset, data)) in non_empty.iter().enumerate() {
+            let len = data.len() as u32;
+            let entry = io_uring::opcode::Write::new(fd, data.as_ptr(), len)
+                .offset(*offset)
+                .build()
+                .user_data(i as u64);
+            let mut flags = Flags::empty();
+            if i < last {
+                flags |= Flags::IO_LINK;
+            } else {
+                flags |= Flags::IO_DRAIN;
+            }
+            let entry = entry.flags(flags);
+            unsafe {
+                submission
+                    .push(&entry)
+                    .map_err(|e| Error::database(format!("Failed to push batched write: {}", e)))?;
+            }
         }
-        ring.submit_and_wait(1)
-            .map_err(|e| Error::database(format!("io_uring submit_and_wait: {}", e)))?;
-        let cqe = ring
-            .completion()
-            .next()
-            .ok_or_else(|| Error::database("io_uring completion queue empty"))?;
-        let res = cqe.result();
-        if res < 0 {
-            return Err(Error::database(format!(
-                "io_uring write failed: {}",
-                std::io::Error::from_raw_os_error(-res)
-            )));
-        }
-        if res as usize != len {
-            return Err(Error::database(format!(
-                "io_uring short write: got {} expected {}",
-                res, len
-            )));
+        drop(submission);
+        ring.submit_and_wait(non_empty.len())
+            .map_err(|e| Error::database(format!("io_uring submit_and_wait batch: {}", e)))?;
+        let mut completion = ring.completion();
+        for _ in 0..non_empty.len() {
+            let cqe = completion
+                .next()
+                .ok_or_else(|| Error::database("io_uring completion queue empty (batch)"))?;
+            let res = cqe.result();
+            if res < 0 {
+                return Err(Error::database(format!(
+                    "io_uring batched write failed: {}",
+                    std::io::Error::from_raw_os_error(-res)
+                )));
+            }
+            let idx = cqe.user_data() as usize;
+            let expected = non_empty[idx].1.len();
+            if res as usize != expected {
+                return Err(Error::database(format!(
+                    "io_uring short write at index {}: got {} expected {}",
+                    idx, res, expected
+                )));
+            }
         }
         Ok(())
     }
@@ -338,13 +489,129 @@ impl BlockIoBackend for IoUringBackend {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn io_uring_batch_writes_env_defaults_off() {
+        std::env::remove_var("RUSTDB_IO_URING_BATCH");
+        assert!(!io_uring_batch_writes_enabled());
+        assert!(!io_uring_batch_writes_enabled());
+    }
+
+    #[test]
+    fn io_uring_batch_writes_env_respects_values() {
+        std::env::set_var("RUSTDB_IO_URING_BATCH", "1");
+        assert!(io_uring_batch_writes_enabled());
+        std::env::set_var("RUSTDB_IO_URING_BATCH", "false");
+        assert!(!io_uring_batch_writes_enabled());
+        std::env::remove_var("RUSTDB_IO_URING_BATCH");
+    }
+
+    #[test]
+    fn std_backend_write_at_batch_roundtrip() -> Result<()> {
+        let dir = TempDir::new().map_err(|e| Error::database(e.to_string()))?;
+        let path = dir.path().join("std_batch.bin");
+        let mut backend = StdFileBackend::create(&path)?;
+        let chunk_a = vec![0xAAu8; 32];
+        let chunk_b = vec![0xBBu8; 32];
+        backend.write_at_batch(&[(0, &chunk_a), (64, &chunk_b)])?;
+        backend.sync()?;
+
+        let mut buf = vec![0u8; 32];
+        backend.read_at(0, &mut buf)?;
+        assert_eq!(buf, chunk_a);
+        backend.read_at(64, &mut buf)?;
+        assert_eq!(buf, chunk_b);
+        Ok(())
+    }
+
+    #[test]
+    fn create_backend_write_at_batch_roundtrip() -> Result<()> {
+        let dir = TempDir::new().map_err(|e| Error::database(e.to_string()))?;
+        let path = dir.path().join("backend_batch.bin");
+        let mut backend = create_backend_for_file(&path, true, false)?;
+        backend.write_at_batch(&[(4, b"abcd"), (16, b"efgh")])?;
+        backend.sync()?;
+
+        let mut buf = [0u8; 4];
+        backend.read_at(4, &mut buf)?;
+        assert_eq!(&buf, b"abcd");
+        backend.read_at(16, &mut buf)?;
+        assert_eq!(&buf, b"efgh");
+        Ok(())
+    }
+
+    #[test]
+    fn write_at_batch_skips_empty_payloads() -> Result<()> {
+        let dir = TempDir::new().map_err(|e| Error::database(e.to_string()))?;
+        let path = dir.path().join("empty_skip.bin");
+        let mut backend = StdFileBackend::create(&path)?;
+        backend.write_at_batch(&[(0, b""), (8, b"x")])?;
+        let mut one = [0u8; 1];
+        backend.read_at(8, &mut one)?;
+        assert_eq!(one, [b'x']);
+        Ok(())
+    }
+}
+
 #[cfg(all(target_os = "linux", feature = "io-uring"))]
 #[cfg(test)]
 mod io_uring_tests {
     use super::*;
+    use std::io::{Error as IoError, ErrorKind};
+    use tempfile::TempDir;
+
+    #[test]
+    fn io_uring_ring_error_is_fallback_classifies_os_errors() {
+        assert!(io_uring_ring_error_is_fallback(
+            &IoError::from_raw_os_error(1)
+        ));
+        assert!(io_uring_ring_error_is_fallback(
+            &IoError::from_raw_os_error(13)
+        ));
+        assert!(io_uring_ring_error_is_fallback(
+            &IoError::from_raw_os_error(38)
+        ));
+        assert!(io_uring_ring_error_is_fallback(
+            &IoError::from_raw_os_error(95)
+        ));
+        assert!(io_uring_ring_error_is_fallback(&IoError::new(
+            ErrorKind::PermissionDenied,
+            "denied"
+        )));
+        assert!(io_uring_ring_error_is_fallback(&IoError::new(
+            ErrorKind::Unsupported,
+            "unsupported"
+        )));
+        assert!(!io_uring_ring_error_is_fallback(&IoError::new(
+            ErrorKind::Other,
+            "other"
+        )));
+    }
+
+    #[test]
+    fn create_backend_uses_std_when_io_uring_disabled_by_env() -> Result<()> {
+        std::env::set_var("RUSTDB_USE_IO_URING", "0");
+        let dir = TempDir::new().map_err(|e| Error::database(e.to_string()))?;
+        let path = dir.path().join("std_fallback.bin");
+        let mut backend = create_backend_for_file(&path, true, false)?;
+        backend.write_at_batch(&[(0, b"std")])?;
+        let mut buf = [0u8; 3];
+        backend.read_at(0, &mut buf)?;
+        assert_eq!(&buf, b"std");
+        std::env::remove_var("RUSTDB_USE_IO_URING");
+        Ok(())
+    }
 
     #[test]
     fn test_io_uring_read_write() {
+        if !super::io_uring_runtime_available() {
+            eprintln!("skip test_io_uring_read_write: io_uring not available");
+            return;
+        }
         let dir = std::env::temp_dir();
         let path = dir.join("rustdb_io_uring_test");
         let _ = std::fs::remove_file(&path);
@@ -358,6 +625,35 @@ mod io_uring_tests {
         backend.read_at(0, &mut buf).expect("read");
         assert_eq!(&buf[..], data.as_slice());
 
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn test_io_uring_write_at_batch_linked() {
+        if !super::io_uring_runtime_available() {
+            eprintln!("skip test_io_uring_write_at_batch_linked: io_uring not available");
+            return;
+        }
+        std::env::set_var("RUSTDB_IO_URING_BATCH", "1");
+        let dir = std::env::temp_dir();
+        let path = dir.join("rustdb_io_uring_batch_test");
+        let _ = std::fs::remove_file(&path);
+
+        let mut backend = IoUringBackend::create(&path).expect("create");
+        let a = vec![1u8; 16];
+        let b = vec![2u8; 16];
+        backend
+            .write_at_batch(&[(0, &a), (32, &b)])
+            .expect("batched write");
+        backend.sync().expect("sync");
+
+        let mut buf = vec![0u8; 16];
+        backend.read_at(0, &mut buf).expect("read a");
+        assert_eq!(buf, a);
+        backend.read_at(32, &mut buf).expect("read b");
+        assert_eq!(buf, b);
+
+        std::env::remove_var("RUSTDB_IO_URING_BATCH");
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/storage/cached_file_manager.rs
+++ b/src/storage/cached_file_manager.rs
@@ -86,6 +86,20 @@ impl CachedFileManager {
         Ok(())
     }
 
+    /// Writes multiple pages in one backend batch when io_uring batching is enabled.
+    pub fn write_pages_batch(
+        &mut self,
+        file_id: AdvancedFileId,
+        pages: &[(PageId, &[u8])],
+    ) -> Result<()> {
+        self.inner.write_pages_batch(file_id, pages)?;
+        let mut cache = self.cache.lock().unwrap();
+        for &(page_id, data) in pages {
+            cache.put(file_id, page_id, data.to_vec());
+        }
+        Ok(())
+    }
+
     /// Synchronizes a file to disk
     pub fn sync_file(&mut self, file_id: AdvancedFileId) -> Result<()> {
         self.inner.sync_file(file_id)
@@ -117,5 +131,36 @@ impl CachedFileManager {
         for &page_id in page_ids {
             cache.remove(file_id, page_id);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::database_file::{DatabaseFileType, ExtensionStrategy, BLOCK_SIZE};
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_write_pages_batch_updates_cache() -> crate::common::Result<()> {
+        let temp_dir = TempDir::new().map_err(|e| crate::common::Error::database(e.to_string()))?;
+        let mut manager = CachedFileManager::new(temp_dir.path(), 8)?;
+
+        let file_id = manager.create_database_file(
+            "cached_batch.db",
+            DatabaseFileType::Data,
+            7,
+            ExtensionStrategy::Fixed,
+        )?;
+
+        let page_a = 1;
+        let page_b = 2;
+        let data_a = vec![0x11u8; BLOCK_SIZE];
+        let data_b = vec![0x22u8; BLOCK_SIZE];
+        manager.write_pages_batch(file_id, &[(page_a, &data_a), (page_b, &data_b)])?;
+
+        assert_eq!(manager.read_page(file_id, page_a)?, data_a);
+        assert_eq!(manager.read_page(file_id, page_b)?, data_b);
+
+        Ok(())
     }
 }

--- a/src/storage/file_manager.rs
+++ b/src/storage/file_manager.rs
@@ -259,6 +259,43 @@ impl DatabaseFile {
         Ok(())
     }
 
+    /// Writes multiple data blocks in one backend batch (io_uring link/drain when enabled).
+    pub fn write_blocks_batch(&mut self, blocks: &[(BlockId, &[u8])]) -> Result<()> {
+        if blocks.is_empty() {
+            return Ok(());
+        }
+        if self.read_only {
+            return Err(Error::database("File is open for reading only".to_string()));
+        }
+        for (_, data) in blocks {
+            if data.len() != BLOCK_SIZE {
+                return Err(Error::database(format!(
+                    "Invalid block size: {} (expected {})",
+                    data.len(),
+                    BLOCK_SIZE
+                )));
+            }
+        }
+        let max_block = blocks.iter().map(|(id, _)| *id).max().unwrap_or(0);
+        if max_block >= self.header.total_blocks as u64 {
+            self.extend_file((max_block + 1) as u32)?;
+        }
+        let writes: Vec<(u64, &[u8])> = blocks
+            .iter()
+            .map(|(block_id, data)| {
+                let offset = BLOCK_SIZE as u64 + (*block_id as u64 * BLOCK_SIZE as u64);
+                (offset, *data)
+            })
+            .collect();
+        self.backend.write_at_batch(&writes)?;
+        if max_block >= self.header.used_blocks as u64 {
+            self.header.used_blocks = (max_block + 1) as u32;
+            self.header.touch();
+            self.header_dirty = true;
+        }
+        Ok(())
+    }
+
     /// Extends the file to the specified number of blocks
     pub fn extend_file(&mut self, new_block_count: u32) -> Result<()> {
         if self.read_only {
@@ -586,6 +623,23 @@ mod tests {
 
         // Close file
         manager.close_file(file_id)?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_write_blocks_batch() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("batch.db");
+
+        let mut db_file = DatabaseFile::create(1, &file_path)?;
+        let block_a = vec![10u8; BLOCK_SIZE];
+        let block_b = vec![20u8; BLOCK_SIZE];
+        db_file.write_blocks_batch(&[(1, &block_a), (3, &block_b)])?;
+
+        assert_eq!(db_file.read_block(1)?, block_a);
+        assert_eq!(db_file.read_block(3)?, block_b);
+        assert_eq!(db_file.used_blocks(), 4);
 
         Ok(())
     }

--- a/src/storage/page_manager.rs
+++ b/src/storage/page_manager.rs
@@ -542,8 +542,15 @@ impl PageManager {
             let page_ids: Vec<PageId> = to_flush.iter().map(|(id, _)| *id).collect();
 
             let write_batch = |pm: &mut Self, pages: &[(PageId, Vec<u8>)]| -> Result<usize> {
-                for (page_id, data) in pages {
-                    pm.file_manager.write_page(file_id, *page_id, data)?;
+                use crate::storage::block_io::io_uring_batch_writes_enabled;
+                if io_uring_batch_writes_enabled() && pages.len() > 1 {
+                    let refs: Vec<(PageId, &[u8])> =
+                        pages.iter().map(|(id, d)| (*id, d.as_slice())).collect();
+                    pm.file_manager.write_pages_batch(file_id, &refs)?;
+                } else {
+                    for (page_id, data) in pages {
+                        pm.file_manager.write_page(file_id, *page_id, data)?;
+                    }
                 }
                 Ok(pages.len())
             };


### PR DESCRIPTION
## Summary
- Batched writes in flush path; io_uring with EPERM fallback to sync sequential.
- Docker io-uring feature; \RUSTDB_IO_URING_BATCH=1\ in CI.

## Test plan
- [x] clippy
- [ ] bench_tpcc_throughput

Made with [Cursor](https://cursor.com)