### PR TITLE
perf(tpcc): arch PR7 — WAL group commit tuning

### DIFF
--- a/scripts/tpcc_throughput_ci.sh
+++ b/scripts/tpcc_throughput_ci.sh
@@ -20,7 +20,8 @@
 #   RUSTDB_GROUP_COMMIT_ENABLED=1 — WAL group commit (default on when unset in engine)
 #   RUSTDB_GROUP_COMMIT_INTERVAL_MS — group commit timer (default 1 ms in container;
 #     run-20 A/B: GROUP_COMMIT_INTERVAL_MS=2 may reduce WAL fsync pressure vs 1 ms)
-#   RUSTDB_GROUP_COMMIT_MAX_BATCH — max records per group commit batch (default 10)
+#   RUSTDB_GROUP_COMMIT_MAX_BATCH / RUSTDB_GROUP_COMMIT_COUNT — max records per group commit batch
+#   RUSTDB_WAL_SYNC_MODE=batch — group-commit fsync batching (SyncLevel::Batch; safe prod default unchanged)
 #   RUSTDB_SQL_WORKER_COUNT — QUIC connection SQL worker threads (default 16; try 32 via workflow_dispatch)
 #   RUSTDB_TPCC_DEFER_INDEX_SYNC=1 — batch secondary-index updates at COMMIT (native TPC-C)
 #   Commit phase log fields (RUSTDB_SQL_PHASE_LOG=1): commit_table_map_lock_us,
@@ -96,8 +97,9 @@ docker run -d --name "$CONTAINER_NAME" \
   -e NO_COLOR=1 \
   -e RUSTDB_SQL_PHASE_LOG="${RUSTDB_SQL_PHASE_LOG:-1}" \
   -e RUSTDB_GROUP_COMMIT_ENABLED="${RUSTDB_GROUP_COMMIT_ENABLED:-1}" \
-  -e RUSTDB_GROUP_COMMIT_INTERVAL_MS="${RUSTDB_GROUP_COMMIT_INTERVAL_MS:-1}" \
-  -e RUSTDB_GROUP_COMMIT_MAX_BATCH="${RUSTDB_GROUP_COMMIT_MAX_BATCH:-32}" \
+  -e RUSTDB_GROUP_COMMIT_INTERVAL_MS="${RUSTDB_GROUP_COMMIT_INTERVAL_MS:-2}" \
+  -e RUSTDB_GROUP_COMMIT_MAX_BATCH="${RUSTDB_GROUP_COMMIT_MAX_BATCH:-${RUSTDB_GROUP_COMMIT_COUNT:-16}}" \
+  -e RUSTDB_WAL_SYNC_MODE="${RUSTDB_WAL_SYNC_MODE:-batch}" \
   -e RUSTDB_TPCC_DEFER_INDEX_SYNC="${RUSTDB_TPCC_DEFER_INDEX_SYNC:-1}" \
   ${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML:+-e "RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML=${RUSTDB_DEFER_HEAP_FLUSH_AFTER_DML}"} \
   -e RUSTDB_BENCH_DEFER_HEAP_FSYNC="${RUSTDB_BENCH_DEFER_HEAP_FSYNC:-1}" \

--- a/src/logging/log_writer.rs
+++ b/src/logging/log_writer.rs
@@ -62,6 +62,8 @@ pub enum SyncLevel {
     Periodic,
     /// Sync after each commit
     OnCommit,
+    /// Group-commit batch: one fsync per interval / max-batch (TPC-C bench preset)
+    Batch,
     /// Sync after every write (slow but safest)
     Always,
 }
@@ -87,6 +89,20 @@ impl LogWriterConfig {
         c.force_flush_immediately = true;
         c.synchronous_commit = true;
         c.group_commit_enabled = false;
+        c.sync_level = SyncLevel::OnCommit;
+        c
+    }
+
+    /// WAL group commit for throughput benchmarks: durable commits batched by interval/count.
+    pub fn batch_group_commit(log_directory: PathBuf) -> Self {
+        let mut c = Self::default();
+        c.log_directory = log_directory;
+        c.sync_level = SyncLevel::Batch;
+        c.force_flush_immediately = false;
+        c.synchronous_commit = true;
+        c.group_commit_enabled = true;
+        c.group_commit_interval_ms = 2;
+        c.group_commit_max_batch = 64;
         c
     }
 }
@@ -724,7 +740,7 @@ impl LogWriter {
             record: record.clone(),
             response_tx: Some(response_tx),
             force_sync: self.config.synchronous_commit,
-            force_flush_immediately: true,
+            force_flush_immediately: self.config.force_flush_immediately,
         };
 
         self.write_tx

--- a/src/logging/log_writer.rs
+++ b/src/logging/log_writer.rs
@@ -739,7 +739,8 @@ impl LogWriter {
         let request = LogWriteRequest {
             record: record.clone(),
             response_tx: Some(response_tx),
-            force_sync: self.config.synchronous_commit,
+            // Always wait for a flush; `synchronous_commit` controls fsync inside `write_records_to_file`.
+            force_sync: true,
             force_flush_immediately: self.config.force_flush_immediately,
         };
 
@@ -1093,6 +1094,47 @@ mod tests {
         assert!(stats.total_bytes_written > 0);
         assert!(stats.sync_operations >= 1);
         assert!(stats.average_write_time_us > 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn batch_group_commit_preset_tuning() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let cfg = LogWriterConfig::batch_group_commit(dir.path().to_path_buf());
+        assert_eq!(cfg.sync_level, SyncLevel::Batch);
+        assert!(cfg.group_commit_enabled);
+        assert!(!cfg.force_flush_immediately);
+        assert!(cfg.synchronous_commit);
+        assert_eq!(cfg.group_commit_interval_ms, 2);
+        assert_eq!(cfg.group_commit_max_batch, 64);
+    }
+
+    #[cfg_attr(miri, ignore)]
+    #[tokio::test]
+    async fn write_log_durable_waits_for_group_commit_flush() -> Result<()> {
+        let temp_dir = TempDir::new().unwrap();
+        let mut config = LogWriterConfig::default();
+        config.log_directory = temp_dir.path().to_path_buf();
+        config.synchronous_commit = false;
+        config.group_commit_enabled = true;
+        config.force_flush_immediately = false;
+        config.group_commit_interval_ms = 5;
+        config.group_commit_max_batch = 64;
+
+        let writer = LogWriter::new(config)?;
+
+        let record = LogRecord::new_transaction_commit(0, 1, vec![(1, 10)], None);
+        let lsn = writer.write_log_durable(record).await?;
+        assert!(lsn > 0);
+
+        let stats = writer.get_statistics();
+        assert!(stats.total_records_written >= 1);
+        assert!(stats.total_bytes_written > 0);
+        assert!(
+            stats.sync_operations >= 1,
+            "durable write should complete only after a group-commit flush"
+        );
 
         Ok(())
     }

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -4723,6 +4723,45 @@ mod tests {
     }
 
     #[test]
+    fn sql_engine_create_insert_survives_reopen_fast_durability() {
+        // Regression for Docker stateful smoke step 3: CREATE in one process, INSERT in another,
+        // SELECT after reopen must see rows (Fast durability + group commit must still flush WAL).
+        let dir = TempDir::new().unwrap();
+        {
+            let eng = SqlEngine::open_with_config(
+                dir.path().to_path_buf(),
+                SqlEngineConfig {
+                    durability: DurabilityMode::Fast,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+            let mut ctx = SessionContext::default();
+            eng.execute_sql("CREATE TABLE ss_ct (x INTEGER)", &mut ctx)
+                .unwrap();
+            eng.execute_sql("INSERT INTO ss_ct (x) VALUES (100)", &mut ctx)
+                .unwrap();
+        }
+        let eng = SqlEngine::open_with_config(
+            dir.path().to_path_buf(),
+            SqlEngineConfig {
+                durability: DurabilityMode::Fast,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let mut ctx = SessionContext::default();
+        let out = eng.execute_sql("SELECT x FROM ss_ct", &mut ctx).unwrap();
+        match out {
+            EngineOutput::ResultSet { columns, rows } => {
+                assert_eq!(columns, vec!["x".to_string()]);
+                assert_eq!(rows.len(), 1);
+            }
+            _ => panic!("expected result set"),
+        }
+    }
+
+    #[test]
     fn sql_engine_autocommit_pk_violation_does_not_corrupt_on_reopen() {
         let dir = TempDir::new().unwrap();
         {

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -6,7 +6,7 @@ use crate::logging::checkpoint::{CheckpointConfig, CheckpointManager, DirtyPageF
 use crate::logging::log_record::{
     IsolationLevel as LogIsolationLevel, LogOperationData, LogRecord, LogRecordType, TransactionId,
 };
-use crate::logging::log_writer::{LogWriter, LogWriterConfig};
+use crate::logging::log_writer::{LogWriter, LogWriterConfig, SyncLevel};
 use crate::logging::recovery::{RecoveryConfig, RecoveryManager};
 use crate::network::engine::{engine_error_code, EngineError, SqlIsolationLevel, SqlTransaction};
 use crate::storage::page_manager::PageManager;
@@ -43,10 +43,19 @@ impl SqlEngineWal {
                 cfg.group_commit_interval_ms = ms.max(1);
             }
         }
-        if let Ok(v) = std::env::var("RUSTDB_GROUP_COMMIT_MAX_BATCH") {
+        if let Ok(v) = std::env::var("RUSTDB_GROUP_COMMIT_MAX_BATCH")
+            .or_else(|_| std::env::var("RUSTDB_GROUP_COMMIT_COUNT"))
+        {
             if let Ok(n) = v.parse::<usize>() {
                 cfg.group_commit_max_batch = n.max(1);
             }
+        }
+        let wal_sync_mode = std::env::var("RUSTDB_WAL_SYNC_MODE").ok();
+        if wal_sync_mode.as_deref() == Some("batch") {
+            cfg.sync_level = SyncLevel::Batch;
+            cfg.force_flush_immediately = false;
+            cfg.group_commit_enabled = true;
+            cfg.synchronous_commit = true;
         }
         cfg.force_flush_immediately = std::env::var("RUSTDB_FORCE_FLUSH_IMMEDIATELY")
             .ok()

--- a/src/network/sql_engine_wal.rs
+++ b/src/network/sql_engine_wal.rs
@@ -25,43 +25,48 @@ pub struct SqlEngineWal {
     checkpoint: Mutex<Option<CheckpointManager>>,
 }
 
+/// Applies WAL group-commit tuning from process environment onto `cfg`.
+pub(crate) fn apply_wal_tuning_from_env(cfg: &mut LogWriterConfig, synchronous_commit: bool) {
+    cfg.synchronous_commit = synchronous_commit;
+    // Performance knobs (mainly for Safe mode). Defaults are tuned for throughput while
+    // preserving durability when `synchronous_commit=true`.
+    cfg.group_commit_enabled = std::env::var("RUSTDB_GROUP_COMMIT_ENABLED")
+        .ok()
+        .as_deref()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(true);
+    if let Ok(v) = std::env::var("RUSTDB_GROUP_COMMIT_INTERVAL_MS") {
+        if let Ok(ms) = v.parse::<u64>() {
+            cfg.group_commit_interval_ms = ms.max(1);
+        }
+    }
+    if let Ok(v) = std::env::var("RUSTDB_GROUP_COMMIT_MAX_BATCH")
+        .or_else(|_| std::env::var("RUSTDB_GROUP_COMMIT_COUNT"))
+    {
+        if let Ok(n) = v.parse::<usize>() {
+            cfg.group_commit_max_batch = n.max(1);
+        }
+    }
+    let wal_sync_mode = std::env::var("RUSTDB_WAL_SYNC_MODE").ok();
+    if wal_sync_mode.as_deref() == Some("batch") {
+        cfg.sync_level = SyncLevel::Batch;
+        cfg.force_flush_immediately = false;
+        cfg.group_commit_enabled = true;
+        cfg.synchronous_commit = true;
+    }
+    cfg.force_flush_immediately = std::env::var("RUSTDB_FORCE_FLUSH_IMMEDIATELY")
+        .ok()
+        .as_deref()
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+}
+
 impl SqlEngineWal {
     /// Opens WAL under `wal_dir` (e.g. `data_dir/.rustdb/wal`), after recovery has run.
     pub fn open(wal_dir: &Path, synchronous_commit: bool) -> DbResult<Self> {
         let mut cfg = LogWriterConfig::default();
         cfg.log_directory = wal_dir.to_path_buf();
-        cfg.synchronous_commit = synchronous_commit;
-        // Performance knobs (mainly for Safe mode). Defaults are tuned for throughput while
-        // preserving durability when `synchronous_commit=true`.
-        cfg.group_commit_enabled = std::env::var("RUSTDB_GROUP_COMMIT_ENABLED")
-            .ok()
-            .as_deref()
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(true);
-        if let Ok(v) = std::env::var("RUSTDB_GROUP_COMMIT_INTERVAL_MS") {
-            if let Ok(ms) = v.parse::<u64>() {
-                cfg.group_commit_interval_ms = ms.max(1);
-            }
-        }
-        if let Ok(v) = std::env::var("RUSTDB_GROUP_COMMIT_MAX_BATCH")
-            .or_else(|_| std::env::var("RUSTDB_GROUP_COMMIT_COUNT"))
-        {
-            if let Ok(n) = v.parse::<usize>() {
-                cfg.group_commit_max_batch = n.max(1);
-            }
-        }
-        let wal_sync_mode = std::env::var("RUSTDB_WAL_SYNC_MODE").ok();
-        if wal_sync_mode.as_deref() == Some("batch") {
-            cfg.sync_level = SyncLevel::Batch;
-            cfg.force_flush_immediately = false;
-            cfg.group_commit_enabled = true;
-            cfg.synchronous_commit = true;
-        }
-        cfg.force_flush_immediately = std::env::var("RUSTDB_FORCE_FLUSH_IMMEDIATELY")
-            .ok()
-            .as_deref()
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        apply_wal_tuning_from_env(&mut cfg, synchronous_commit);
         let runtime = Runtime::new().map_err(|e| DbError::database(e.to_string()))?;
         let writer = {
             let _guard = runtime.enter();
@@ -680,6 +685,55 @@ mod tests {
     use crate::network::sql_engine::{table_page_manager, SqlEngine};
     use std::collections::HashSet;
     use tempfile::TempDir;
+
+    fn clear_wal_tuning_env() {
+        for key in [
+            "RUSTDB_GROUP_COMMIT_ENABLED",
+            "RUSTDB_GROUP_COMMIT_INTERVAL_MS",
+            "RUSTDB_GROUP_COMMIT_MAX_BATCH",
+            "RUSTDB_GROUP_COMMIT_COUNT",
+            "RUSTDB_WAL_SYNC_MODE",
+            "RUSTDB_FORCE_FLUSH_IMMEDIATELY",
+        ] {
+            std::env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn wal_tuning_env_parsing() {
+        clear_wal_tuning_env();
+        std::env::set_var("RUSTDB_GROUP_COMMIT_INTERVAL_MS", "7");
+        std::env::set_var("RUSTDB_GROUP_COMMIT_COUNT", "42");
+
+        let mut cfg = LogWriterConfig::default();
+        apply_wal_tuning_from_env(&mut cfg, false);
+
+        assert_eq!(cfg.group_commit_interval_ms, 7);
+        assert_eq!(cfg.group_commit_max_batch, 42);
+        assert!(!cfg.synchronous_commit);
+
+        clear_wal_tuning_env();
+        std::env::set_var("RUSTDB_GROUP_COMMIT_COUNT", "99");
+        std::env::set_var("RUSTDB_GROUP_COMMIT_MAX_BATCH", "12");
+
+        let mut cfg = LogWriterConfig::default();
+        apply_wal_tuning_from_env(&mut cfg, true);
+
+        assert_eq!(cfg.group_commit_max_batch, 12);
+
+        clear_wal_tuning_env();
+        std::env::set_var("RUSTDB_WAL_SYNC_MODE", "batch");
+
+        let mut cfg = LogWriterConfig::default();
+        apply_wal_tuning_from_env(&mut cfg, false);
+
+        assert_eq!(cfg.sync_level, SyncLevel::Batch);
+        assert!(cfg.group_commit_enabled);
+        assert!(!cfg.force_flush_immediately);
+        assert!(cfg.synchronous_commit);
+
+        clear_wal_tuning_env();
+    }
 
     #[test]
     fn bench_defer_heap_fsync_respects_env() {


### PR DESCRIPTION
## Summary
- Bench-friendly group commit defaults: 2 ms interval, max batch 16 (not 64).
- \RUSTDB_GROUP_COMMIT_COUNT\ alias; log_writer/sql_engine_wal wiring.

## Test plan
- [x] clippy
- [ ] bench: payment commit p50 < 10 ms guardrail

Made with [Cursor](https://cursor.com)