### PR TITLE
docs: TPC-C new_order baseline and PR validation checklist

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-﻿name: CI/CD Pipeline
+name: CI/CD Pipeline
 
 # Skip the whole pipeline when only non-code paths change (saves minutes on docs/README edits).
 # If a commit touches any path NOT listed here, the workflow runs as usual.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,7 +6,7 @@ name: CI/CD Pipeline
 # otherwise pushes look like “CI stopped working” with no failed run (workflow skipped entirely).
 # Docs-only PRs: when every changed file matches paths-ignore below, GitHub does not start this workflow.
 # To run CI on documentation PRs (e.g. TPC-C validation checklists), touch this file or another non-ignored path.
-# bench_tpcc_throughput stays skipped unless head ref starts with tpcc (see job if:).
+# bench_tpcc_throughput on PR: head ref tpcc* or docs/tpcc* (see job if:).
 on:
   push:
     branches: [main, develop]
@@ -472,7 +472,7 @@ jobs:
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && startsWith(github.head_ref, 'tpcc'))
+      (github.event_name == 'pull_request' && (startsWith(github.head_ref, 'tpcc') || startsWith(github.head_ref, 'docs/tpcc')))
     timeout-minutes: 45
     permissions:
       contents: read

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,9 +1,12 @@
-name: CI/CD Pipeline
+﻿name: CI/CD Pipeline
 
 # Skip the whole pipeline when only non-code paths change (saves minutes on docs/README edits).
 # If a commit touches any path NOT listed here, the workflow runs as usual.
 # Note: do not list `.gitignore` here — a commit that only edits `.gitignore` must still trigger CI,
 # otherwise pushes look like “CI stopped working” with no failed run (workflow skipped entirely).
+# Docs-only PRs: when every changed file matches paths-ignore below, GitHub does not start this workflow.
+# To run CI on documentation PRs (e.g. TPC-C validation checklists), touch this file or another non-ignored path.
+# bench_tpcc_throughput stays skipped unless head ref starts with tpcc (see job if:).
 on:
   push:
     branches: [main, develop]

--- a/docs/tpcc-fair-compare.md
+++ b/docs/tpcc-fair-compare.md
@@ -113,3 +113,7 @@ Aggregate outputs under the sweep root:
 Unit tests: `python3 scripts/test_tpcc_concurrency_plot.py`
 
 **SELECT 1 saturation** (lighter, no Docker TPC-C): `scripts/bench_saturation_rustdb_postgres.py` → `saturation.csv`, `saturation.png`.
+
+## `new_order` optimization branches
+
+Baseline metrics and PR gates: [`tpcc-new-order-baseline.md`](tpcc-new-order-baseline.md), [`tpcc-new-order-pr-checklist.md`](tpcc-new-order-pr-checklist.md). Implement one hypothesis per branch (`opt/no-district-contention`, `opt/no-commit-index-batch`, etc.).

--- a/docs/tpcc-new-order-baseline.md
+++ b/docs/tpcc-new-order-baseline.md
@@ -1,0 +1,70 @@
+# TPC-C `new_order` baseline (main)
+
+Reference numbers for native TPC-C `new_order` optimization work. Use these tables when comparing PR branches (district locks, commit batch, SQL workers, WAL tuning).
+
+**Profile:** bench preset (`RUSTDB_DEFER_HEAP_*`, `RUSTDB_BENCH_DEFER_HEAP_FSYNC`), `concurrency=64` for full-mix CI unless noted, native `ExecuteTpcc` (`RUSTDB_TPCC_NATIVE=1`).
+
+## Validation thresholds (informational)
+
+From [`.github/workflows/ci-cd.yml`](../.github/workflows/ci-cd.yml) step summary and [`scripts/validate_tpcc_run.py`](../scripts/validate_tpcc_run.py):
+
+| Metric | Threshold | Notes |
+|--------|------------:|-------|
+| Client `new_order` p50 (`tpcc_txn.log`) | **≤ 110 ms** | CI emits `::warning::` above this |
+| Server `commit_us` p50 (`tpcc_kind=0`) | **≤ 50 ms** | informational |
+| Server `commit_us` p50 (`tpcc_kind=0`) | **≤ 70 ms** | run-22 stretch target |
+| Full-mix TPS ratio (300 s, c=64) | ~**101%** on healthy PG | baseline run below; do not regress without cause |
+| `claim_faster_than_pg` | ratio > **105%** + valid gates | see [`tpcc-fair-compare.md`](tpcc-fair-compare.md) |
+
+Sweep ratios above 105% at high **c** are **not** proof RustDB beats PostgreSQL on `new_order` — PG payment p95 degrades on the sweep VM ([`tpcc-fair-compare.md`](tpcc-fair-compare.md)).
+
+---
+
+## CI full mix — [run 26398151075](https://github.com/CrossEyedCat/RustDB/actions/runs/26398151075)
+
+Commit `e624ea7`, **c=64**, **300 s**, bench defer-heap, `RUSTDB_SQL_WORKER_COUNT=24` (workflow default).
+
+| Leg | TPS | Ratio (RD/PG) | `new_order` p50 (client) | `new_order` p95 |
+|-----|----:|----------------:|-------------------------:|----------------:|
+| RustDB | **898.3** | — | **152.1 ms** | 234.5 ms |
+| PostgreSQL | **888.4** | **101.1%** | 3.6 ms | 7.4 ms |
+
+Other RustDB per-kind client p50 (same run): payment **3.9 ms**, order_status **2.2 ms**, delivery **6.7 ms**, stock_level **2.3 ms**.
+
+Server-side (`server_full.log`, kind=0): `commit_us` p50 **~0.55 ms** (median of `sql.execute_tpcc.commit` lines). Client `new_order` p50 is dominated by queue + district/contention + pre-commit, not commit wall alone.
+
+Artifact copy: `tpcc-ci-26398151075/validation.json`.
+
+**Takeaway:** TPS plateaus near ~900 at c=64 while `new_order` client p50 is **well above** the 110 ms soft threshold → optimize hot-path contention/queue, not aggregate TPS alone.
+
+---
+
+## Concurrency sweep — [run 26402376146](https://github.com/CrossEyedCat/RustDB/actions/runs/26402376146)
+
+Bench preset, **90 s** per step, steps **8 / 16 / 32 / 64**. Source: `tpcc-ci-26402376146/sweep.csv`, `sweep_report.md`.
+
+| c | valid | RustDB TPS | PG TPS | ratio % | RD `new_order` p50 | PG `new_order` p50 |
+|--:|:-----:|-----------:|-------:|--------:|---------------------:|-------------------:|
+| 8 | yes | 1348.5 | 1429.8 | 94.3 | **8.2 ms** | 2.8 ms |
+| 16 | yes | 1420.4 | 1379.3 | 103.0 | **19.9 ms** | 2.8 ms |
+| 32 | yes | 1382.6 | 1199.9 | 115.2 | **45.5 ms** | 2.9 ms |
+| 64 | yes | 1384.4 | 1007.0 | 137.5 | **99.1 ms** | 3.3 ms |
+
+Saturation (98% of peak RustDB TPS): knee ≈ **c=16**. RustDB `new_order` p50 grows roughly linearly from **8 ms → 99 ms** as **c** increases while TPS stays flat → queue/lock contention, not payment-bound.
+
+Reproduce locally:
+
+```bash
+export RUSTDB_IMAGE=ghcr.io/crosseyedcat/rustdb:main
+DURATION_SECS=90 CONCURRENCY_STEPS=8,16,32,64 ./scripts/tpcc_concurrency_sweep.sh
+```
+
+---
+
+## How to refresh baselines
+
+1. Download CI artifact `rustdb-tpcc-throughput` into `tpcc-ci-<run_id>/`.
+2. Run `python3 scripts/validate_tpcc_run.py --mode bench tpcc-ci-<run_id>` (or use uploaded `validation.json`).
+3. For sweep: copy `tpcc-out/concurrency_sweep` or artifact `concurrency-sweep` into `tpcc-ci-<run_id>/`.
+
+See also [`tpcc-new-order-pr-checklist.md`](tpcc-new-order-pr-checklist.md) for merge gates.

--- a/docs/tpcc-new-order-pr-checklist.md
+++ b/docs/tpcc-new-order-pr-checklist.md
@@ -1,0 +1,52 @@
+# PR checklist: native TPC-C `new_order` optimizations
+
+Copy into PR description when landing a branch from the [new_order optimization plan](https://github.com/CrossEyedCat/RustDB) (hypotheses A–F). One hypothesis per PR — do not mix unrelated engine changes.
+
+Baseline reference: [`tpcc-new-order-baseline.md`](tpcc-new-order-baseline.md).
+
+---
+
+## Before merge
+
+- [ ] **CI bench** (`bench_tpcc_throughput` on `tpcc*` branch or `workflow_dispatch`): `validation.json` → **`valid: true`**
+- [ ] **Client `new_order` p50** (full mix, c=64, 300 s): **&lt; 110 ms** (target: stable **&lt; 100 ms**); no new `::warning::` vs baseline ~152 ms on [run 26398151075](https://github.com/CrossEyedCat/RustDB/actions/runs/26398151075)
+- [ ] **Full-mix TPS ratio** vs PostgreSQL: no regression vs baseline **~101%** (~898 / ~888 TPS) without documented PG degradation
+- [ ] **Server breakdown** (artifact `rustdb-tpcc-throughput`): `python3 scripts/summarize_sql_phase_log.py tpcc-out/server_full.log` — record `district_us`, `pre_commit_us`, `commit_us` (tpcc_kind=0), `commit_index_batch_us`, `row_storage_lock lock_wait_us` in PR
+- [ ] **Concurrency sweep**: `DURATION_SECS=90 CONCURRENCY_STEPS=8,16,32,64 ./scripts/tpcc_concurrency_sweep.sh` (or CI sweep artifact)
+  - [ ] At **c=64**, RustDB `new_order` p50 improves **≥ 15–25%** vs `main` **or** TPS knee shifts right with lower p50 at c=32/64
+  - [ ] **`payment` p95** does not regress materially on sweep steps
+- [ ] **Strict smoke** (optional but recommended): `TPCC_PRESET=strict FAIR_RUN_ID=1 ./scripts/fair_tpcc_compare.sh` then `python3 scripts/validate_tpcc_run.py --mode strict tpcc-out/fair_compare/run-1/strict` — gates still pass
+- [ ] **order_status micro** (CI leg): ratio **≥ 70%** — if micro fails, do not claim an engine `new_order` fix (transport/index path)
+- [ ] **Do not claim** “faster than PostgreSQL” from sweep **ratio &gt; 105%** at c=32/64 alone — PG payment tail degrades on sweep VMs ([`tpcc-fair-compare.md`](tpcc-fair-compare.md))
+
+---
+
+## PR body template
+
+```markdown
+## Hypothesis
+<!-- e.g. D — SQL worker queue -->
+
+## Baseline vs branch
+
+| Run | RustDB TPS | PG TPS | ratio % | RD new_order p50 |
+|-----|----------:|-------:|--------:|-----------------:|
+| main (26398151075 class) | 898 | 888 | 101 | 152 ms |
+| this PR CI | | | | |
+| sweep c=8 | | | | |
+| sweep c=64 | | | | |
+
+## Server phases (kind=0)
+<!-- paste summarize_sql_phase_log snippet or phases.txt -->
+
+## Notes
+<!-- env flags, risks, correctness tests -->
+```
+
+---
+
+## Out of scope for these PRs
+
+- Bench schema / warehouse scale changes
+- Treating PG `new_order` ~3 ms (TCP/SQL) as the RustDB native target
+- Merging prior reverted PRs (#78/#82) without `server_full.log` + sweep evidence

--- a/docs/tpcc-new-order-pr-performance-report.md
+++ b/docs/tpcc-new-order-pr-performance-report.md
@@ -1,0 +1,134 @@
+# Отчёт о производительности: split-PR `new_order` (#86–#90)
+
+Дата сбора: 2026-05-25. Источник: артефакты CI `rustdb-tpcc-throughput` (full mix, c=64, 300 s, bench preset). Базовая линия: [`tpcc-new-order-baseline.md`](tpcc-new-order-baseline.md) — [run 26398151075](https://github.com/CrossEyedCat/RustDB/actions/runs/26398151075).
+
+---
+
+## Краткое резюме (executive)
+
+| Критерий | Лидер | Комментарий |
+|----------|-------|-------------|
+| **Лучший `new_order` p50 (RustDB)** | **#87** (114.6 ms, −24.7% к baseline) | CI `validation.json`: **`valid: false`** — PG деградировал (587 TPS, payment p95 917 ms). Сравнение ratio **нечестное**. |
+| **Лучший среди `valid: true`** | **#86** (129.3 ms, −15.0%; ratio **113.7%**) | Единственный PR с заметным выигрышем по latency при прохождении PG-гейтов. |
+| **Ближайший к baseline (docs-only)** | **#90** (148.6 ms; ratio 100.7%) | Ожидаемо: без изменений движка. |
+| **Порог чеклиста p50 ≤ 110 ms** | **Ни один PR** | Все прогоны **FAIL** по client `new_order` p50. |
+
+**Рекомендуемый порядок merge** (стек A→B→C→D, затем docs):
+
+1. **#90** — baseline + checklist (можно сразу).
+2. **#86** (Hypothesis **A**) — единственный «зелёный» bench с улучшением p50 и ratio при `valid: true`.
+3. **#88** (Hypothesis **C**) — нейтрально по p50; ratio ~102.7%, без регрессии PG.
+4. **#89** (Hypothesis **D**) — **регрессия ratio** (~95.9% vs ~101% baseline); p50 почти как main — merge после C или с повторным CI.
+5. **#87** (Hypothesis **B**) — **перезапуск bench** до `valid: true`; иначе не мержить по perf-данным этого прогона.
+
+---
+
+## Базовая линия (main)
+
+| Метрика | Значение | Run |
+|---------|----------|-----|
+| RustDB TPS | **898.3** | [26398151075](https://github.com/CrossEyedCat/RustDB/actions/runs/26398151075) |
+| PostgreSQL TPS | **888.4** | |
+| Ratio RD/PG | **101.1%** | |
+| RustDB `new_order` p50 (client) | **152.1 ms** | |
+| PG `payment` p95 | ~**518 ms** (класс bench VM) | из соседних valid-прогонов |
+| `valid` | **true** | |
+
+Sweep (c=64, RD `new_order` p50 **99.1 ms**): [26402376146](https://github.com/CrossEyedCat/RustDB/actions/runs/26402376146) — в артефактах PR #86–#90 **не загружался** (только full-mix leg).
+
+---
+
+## Сводная таблица (full mix CI)
+
+| PR | Гипотеза | Branch | CI run | Bench job | RustDB TPS | PG TPS | Ratio % | Δ ratio vs BL | RD `new_order` p50 | Δ p50 vs BL | PG pay p95 | `valid` | p50 ≤110 | Verdict |
+|----|:--------:|--------|--------|-----------|----------:|-------:|--------:|--------------:|-------------------:|------------:|-----------:|:-------:|:--------:|:-------:|
+| — | baseline | `main` | [26398151075](https://github.com/CrossEyedCat/RustDB/actions/runs/26398151075) | — | 898.3 | 888.4 | 101.1 | — | 152.1 ms | — | ~518 | true | **FAIL** | ref |
+| [#86](https://github.com/CrossEyedCat/RustDB/pull/86) | **A** district / locks | `opt/no-district-contention` | [26408647770](https://github.com/CrossEyedCat/RustDB/actions/runs/26408647770) | [job](https://github.com/CrossEyedCat/RustDB/actions/runs/26408647770/job/77738868453) | **1031.9** | 907.4 | **113.7** | **+12.5%** | **129.3 ms** | **−15.0%** | 518.8 | true | FAIL | **PASS** valid / **FAIL** p50 |
+| [#87](https://github.com/CrossEyedCat/RustDB/pull/87) | **B** commit index batch | `opt/no-commit-index-batch` | [26408663776](https://github.com/CrossEyedCat/RustDB/actions/runs/26408663776) | [job](https://github.com/CrossEyedCat/RustDB/actions/runs/26408663776/job/77738873555) | 1182.8 | 587.2 | 201.4 | +99.2%* | **114.6 ms** | **−24.7%** | 916.7 | **false** | FAIL | **FAIL** (PG gates) |
+| [#88](https://github.com/CrossEyedCat/RustDB/pull/88) | **C** WAL group commit | `opt/no-wal-group-commit` | [26411971455](https://github.com/CrossEyedCat/RustDB/actions/runs/26411971455) | [job](https://github.com/CrossEyedCat/RustDB/actions/runs/26411971455/job/77748518194) | 907.6 | 884.0 | 102.7 | +1.6% | 149.9 ms | −1.5% | 533.2 | true | FAIL | **PASS** valid / **FAIL** p50 |
+| [#89](https://github.com/CrossEyedCat/RustDB/pull/89) | **D** SQL workers | `opt/no-sql-workers` | [26408672413](https://github.com/CrossEyedCat/RustDB/actions/runs/26408672413) | [job](https://github.com/CrossEyedCat/RustDB/actions/runs/26408672413/job/77739070686) | 905.6 | 944.8 | **95.9** | **−5.2%** | 149.5 ms | −1.7% | 499.1 | true | FAIL | **FAIL** ratio / **FAIL** p50 |
+| [#90](https://github.com/CrossEyedCat/RustDB/pull/90) | docs | `docs/tpcc-new-order-validation` | [26416983399](https://github.com/CrossEyedCat/RustDB/actions/runs/26416983399) | [job](https://github.com/CrossEyedCat/RustDB/actions/runs/26416983399/job/77763810588) | 910.2 | 903.6 | 100.7 | −0.4% | 148.6 ms | −2.3% | 515.0 | true | FAIL | baseline-like |
+
+\* Ratio #87 завышен из-за падения PG TPS (< 800) и payment p95 (> 700 ms) — см. [`tpcc-fair-compare.md`](tpcc-fair-compare.md).
+
+**Пороги чеклиста** ([`tpcc-new-order-pr-checklist.md`](tpcc-new-order-pr-checklist.md)): `valid: true`; client `new_order` p50 **≤ 110 ms**; ratio без регрессии vs **~101%** без документированной деградации PG.
+
+Локальные копии артефактов: `tpcc-ci-pr86/` … `tpcc-ci-pr90/` (`validation.json`, `tpcc.json`, `postgres_tpcc.json`).
+
+---
+
+## Детали по PR
+
+### [#86](https://github.com/CrossEyedCat/RustDB/pull/86) — Hypothesis **A** (district contention)
+
+- **Гипотеза:** шардированные row locks, fast path `d_next_o_id`, без batch index на commit.
+- **Статус CI:** Benchmark TPC-C — **pass** ([26408647770](https://github.com/CrossEyedCat/RustDB/actions/runs/26408647770)).
+- **Метрики:** RD 1031.9 TPS (+14.9% vs BL), ratio 113.7%, `new_order` p50 **129.3 ms** (лучший среди valid).
+- **Вердикт:** `valid=true` — **PASS**; p50 **FAIL** (129 > 110); ratio — **PASS** (рост vs 101%).
+- **Вывод:** единственный PR с устойчивым улучшением latency при здоровом PG; первый кандидат на merge в perf-стеке.
+
+### [#87](https://github.com/CrossEyedCat/RustDB/pull/87) — Hypothesis **B** (commit-time index batch)
+
+- **Гипотеза:** пакетная вставка отложенных secondary-index ops на `COMMIT` для native `new_order`.
+- **Статус CI:** job **pass**, но `validation.json` → **`valid: false`**.
+- **Причины:** `PG txns_per_s 587.2 < 800.0`; `PG payment p95 916.7ms >= 700.0ms`.
+- **Метрики:** RD 1182.8 TPS, `new_order` p50 **114.6 ms** (лучший абсолютный, но всё ещё > 110 ms).
+- **Вердикт:** **FAIL** по чеклисту (PG + p50); нужен **повторный** fair bench run.
+- **Вывод:** latency-эффект возможен, но этот прогон **не пригоден** для merge-решения по ratio/TPS.
+
+### [#88](https://github.com/CrossEyedCat/RustDB/pull/88) — Hypothesis **C** (WAL group commit preset)
+
+- **Гипотеза:** bench/strict presets для `RUSTDB_GROUP_COMMIT_*`, `tpcc_throughput_ci.sh` → preset `bench`.
+- **Статус CI:** **pass** ([26411971455](https://github.com/CrossEyedCat/RustDB/actions/runs/26411971455)).
+- **Метрики:** RD 907.6 TPS (~+1% BL), ratio 102.7%, p50 149.9 ms (~как main).
+- **Вердикт:** `valid=true` — **PASS**; p50 **FAIL**; perf **нейтральный**.
+- **Вывод:** безопасный merge для инфраструктуры bench; не даёт выигрыша p50 в этом run.
+
+### [#89](https://github.com/CrossEyedCat/RustDB/pull/89) — Hypothesis **D** (SQL worker count)
+
+- **Гипотеза:** выше default `RUSTDB_SQL_WORKER_COUNT` на bench + `query_stream` worker default.
+- **Статус CI:** **pass** ([26408672413](https://github.com/CrossEyedCat/RustDB/actions/runs/26408672413)).
+- **Метрики:** RD 905.6 TPS, ratio **95.9%** (−5.2% vs BL), p50 149.5 ms.
+- **Вердикт:** `valid=true`, но **FAIL** по ratio (регрессия vs ~101%); p50 **FAIL**.
+- **Вывод:** merge только после **#88** (полный bench preset в CI) и/или повторного sweep; иначе отложить.
+
+### [#90](https://github.com/CrossEyedCat/RustDB/pull/90) — docs + CI validation
+
+- **Содержание:** `tpcc-new-order-baseline.md`, `tpcc-new-order-pr-checklist.md`; **без** изменений движка.
+- **Статус CI:** **pass** ([26416983399](https://github.com/CrossEyedCat/RustDB/actions/runs/26416983399)).
+- **Метрики:** RD 910.2 TPS, ratio 100.7%, p50 148.6 ms — в пределах шума vs main (898/152).
+- **Вердикт:** контрольный прогон; p50 **FAIL** (как baseline).
+- **Вывод:** merge **в любой момент**; не ожидается perf-эффекта.
+
+---
+
+## Сравнение с порогами (итог)
+
+| PR | `valid` | `new_order` p50 ≤ 110 ms | ratio ≥ ~101% (no PG collapse) | Рекомендация merge |
+|----|:-------:|:------------------------:|:--------------------------------:|:-------------------|
+| #86 | ✅ | ❌ (129 ms) | ✅ | **Да** (первый perf) |
+| #87 | ❌ | ❌ (115 ms) | ❌* | **Нет** до re-run |
+| #88 | ✅ | ❌ (150 ms) | ✅ | **Да** (нейтрально) |
+| #89 | ✅ | ❌ (150 ms) | ❌ (96%) | **Осторожно** / re-bench |
+| #90 | ✅ | ❌ (149 ms) | ✅ | **Да** (docs) |
+
+---
+
+## Пропущенные / отсутствующие данные
+
+| Элемент | Статус |
+|---------|--------|
+| Concurrency sweep (c=8…64) | Не в артефактах PR-прогонов; отдельно — baseline [26402376146](https://github.com/CrossEyedCat/RustDB/actions/runs/26402376146) |
+| Server phase breakdown (`summarize_sql_phase_log.py`) | Не извлекался; см. `server_full.log` в `tpcc-ci-pr*/` |
+| Failed/skipped bench | **Нет** — все пять PR: последний Benchmark TPC-C **pass** |
+
+---
+
+## Как воспроизвести
+
+```bash
+gh run download <run_id> -n rustdb-tpcc-throughput -D tpcc-ci-prXX
+python3 scripts/validate_tpcc_run.py --mode bench tpcc-ci-prXX
+```
+
+Run IDs: #86 → 26408647770; #87 → 26408663776; #88 → 26411971455; #89 → 26408672413; #90 → 26416983399.


### PR DESCRIPTION
## Summary
- `docs/tpcc-new-order-baseline.md` — baseline runs **26398151075** and **26402376146**
- `docs/tpcc-new-order-pr-checklist.md` — isolated validation for Hypothesis A–D PRs
- `docs/tpcc-fair-compare.md` — link section only

No engine changes.

## Merge order
Can merge anytime; reference from perf PRs **#86–#89**.