### PR TITLE
perf(tpcc): shard order_line heap by district id

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -544,6 +544,8 @@ jobs:
           MIX: new_order=0.45,payment=0.43,order_status=0.04,delivery=0.04,stock_level=0.04
           RUSTDB_TPCC_NATIVE: "1"
           RUSTDB_TPCC_NATIVE_MICRO: "1"
+          # Native order_line inserts shard by ol_d_id (5 districts in tpcc_seed.sql).
+          RUSTDB_TPCC_ORDER_LINE_SHARDS: "5"
           # Default 24 workers on push; workflow_dispatch A/B: override RUSTDB_SQL_WORKER_COUNT=32
           # on 4+ vCPU runners (edit env below or set in the manual run inputs).
           RUSTDB_SQL_WORKER_COUNT: "24"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -854,12 +854,20 @@ jobs:
           print(f"- postgres txns/s: **{m.get('postgres_txns_per_s', 'n/a')}**")
           print(f"- PG payment p95 (ms): **{m.get('pg_payment_p95_ms', 'n/a')}**")
           ratio = m.get("ratio_percent_rustdb_over_postgres")
+          ratio_ref = m.get("ratio_percent_vs_pg_reference")
           if v.get("valid") and ratio is not None:
-              print(f"- rustdb/postgres ratio: **{ratio:.1f}%** (informational; bench defer profile)")
+              print(f"- rustdb/postgres ratio (raw): **{ratio:.1f}%** (informational; bench defer profile)")
           elif ratio is not None:
-              print(f"- rustdb/postgres ratio: {ratio:.1f}% *(not advertised — validation failed)*")
+              print(f"- rustdb/postgres ratio (raw): {ratio:.1f}% *(not advertised — validation failed)*")
           else:
-              print("- rustdb/postgres ratio: *(unavailable)*")
+              print("- rustdb/postgres ratio (raw): *(unavailable)*")
+          if ratio_ref is not None:
+              pg_ref = m.get("pg_reference_tps_for_claim", "n/a")
+              print(
+                  f"- rustdb/postgres ratio vs PG reference ({pg_ref} TPS): "
+                  f"**{ratio_ref:.1f}%** (used for claim_faster_than_pg)"
+              )
+          print(f"- **claim_faster_than_pg**: {v.get('claim_faster_than_pg')}")
           if not v.get("valid"):
               print("")
               print("> Do not treat ratio as «RustDB faster than PostgreSQL» when valid=false.")

--- a/scripts/test_validate_tpcc_run.py
+++ b/scripts/test_validate_tpcc_run.py
@@ -91,6 +91,28 @@ class ValidateTpccRunTests(unittest.TestCase):
             report["metrics"]["ratio_percent_rustdb_over_postgres"],
             GATES["ratio_claim_min_pct"],
         )
+        # Raw ratio > 105% but PG below reference median -> claim stays false.
+        self.assertFalse(report["claim_faster_than_pg"])
+
+    def test_claim_rejects_slow_pg_spike(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_pair(d, pg_tps=1317.0, rd_tps=1389.0, server_lines=_bench_server_lines())
+            valid, report = validate_run(d, "bench")
+            self.assertTrue(valid)
+            self.assertGreater(
+                report["metrics"]["ratio_percent_rustdb_over_postgres"],
+                GATES["ratio_claim_min_pct"],
+            )
+            self.assertFalse(report["claim_faster_than_pg"])
+
+    def test_claim_true_when_above_reference(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp)
+            _write_pair(d, pg_tps=1400.0, rd_tps=1500.0, server_lines=_bench_server_lines())
+            valid, report = validate_run(d, "bench")
+            self.assertTrue(valid)
+            self.assertTrue(report["claim_faster_than_pg"])
 
     def test_fixture_degraded_pg_fails(self) -> None:
         d = FIXTURES / "degraded_pg"

--- a/scripts/tpcc_order_line_insert_microbench.sh
+++ b/scripts/tpcc_order_line_insert_microbench.sh
@@ -29,8 +29,8 @@ export MIX="new_order=1.0"
 export RUSTDB_TPCC_NATIVE=1
 export RUSTDB_SQL_PHASE_LOG="${RUSTDB_SQL_PHASE_LOG:-1}"
 export RUSTDB_TPCC_NEW_ORDER_OL_CNT="${ORDER_LINE_CNT}"
-# Optional: shard native order_line heap by w_id (default 16 for local microbench).
-export RUSTDB_TPCC_ORDER_LINE_SHARDS="${RUSTDB_TPCC_ORDER_LINE_SHARDS:-16}"
+# Optional: shard native order_line heap by ol_d_id (default 5 = districts in tpcc_seed.sql).
+export RUSTDB_TPCC_ORDER_LINE_SHARDS="${RUSTDB_TPCC_ORDER_LINE_SHARDS:-5}"
 
 chmod +x scripts/tpcc_throughput_ci.sh
 ./scripts/tpcc_throughput_ci.sh

--- a/scripts/tpcc_throughput_ci.sh
+++ b/scripts/tpcc_throughput_ci.sh
@@ -35,6 +35,8 @@
 #     engine fast path: direct index/heap ops + single COMMIT, not 7× SQL per new_order)
 #   RUSTDB_TPCC_NATIVE_MICRO=1 — after the main run, run a short native-only micro leg
 #     (order_status-heavy mix, fewer txns) written to tpcc-native-micro.json
+#   RUSTDB_TPCC_ORDER_LINE_SHARDS — native order_line heap shards by ol_d_id (default 1;
+#     CI/microbench use 5 to match tpcc_seed districts)
 #
 set -euo pipefail
 

--- a/scripts/validate_tpcc_run.py
+++ b/scripts/validate_tpcc_run.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import argparse
 import csv
 import json
+import os
 import re
 import statistics
 import sys
@@ -34,6 +35,22 @@ GATES = {
     "strict_heap_flush_skipped_pct_max": 10.0,
     "ratio_claim_min_pct": 105.0,
 }
+
+# Median PG full-mix TPS from recent CI runs (c=64, 300s). Used so a single slow-PG run
+# does not inflate claim_faster_than_pg. Override with TPCC_PG_REFERENCE_TPS.
+PG_REFERENCE_TPS_DEFAULT = 1380.0
+
+
+def pg_reference_tps() -> float:
+    raw = os.environ.get("TPCC_PG_REFERENCE_TPS")
+    if raw:
+        return float(raw)
+    return PG_REFERENCE_TPS_DEFAULT
+
+
+def pg_tps_for_claim_denominator(pg_tps: float) -> float:
+    """Conservative PG baseline: max(actual, reference median)."""
+    return max(pg_tps, pg_reference_tps())
 
 
 def quantile_ns(samples: list[int], q: float) -> float:
@@ -164,6 +181,11 @@ def validate_run(out_dir: Path, mode: str) -> tuple[bool, dict[str, Any]]:
     pg_tps = num(pg_json, "txns_per_s")
     rd_tps = num(rd_json, "txns_per_s")
     ratio = (100.0 * rd_tps / pg_tps) if pg_tps > 0 else None
+    pg_ref = pg_reference_tps()
+    claim_pg_tps = pg_tps_for_claim_denominator(pg_tps)
+    ratio_vs_pg_reference = (
+        (100.0 * rd_tps / claim_pg_tps) if claim_pg_tps > 0 else None
+    )
 
     pg_stats = txn_kind_stats(pg_log)
     rd_stats = txn_kind_stats(rd_log)
@@ -278,8 +300,8 @@ def validate_run(out_dir: Path, mode: str) -> tuple[bool, dict[str, Any]]:
     valid = len(reasons) == 0
     claim_faster = (
         valid
-        and ratio is not None
-        and ratio > GATES["ratio_claim_min_pct"]
+        and ratio_vs_pg_reference is not None
+        and ratio_vs_pg_reference > GATES["ratio_claim_min_pct"]
     )
 
     report: dict[str, Any] = {
@@ -293,6 +315,9 @@ def validate_run(out_dir: Path, mode: str) -> tuple[bool, dict[str, Any]]:
             "postgres_txns_per_s": pg_tps,
             "rustdb_txns_per_s": rd_tps,
             "ratio_percent_rustdb_over_postgres": ratio,
+            "pg_reference_tps_for_claim": pg_ref,
+            "pg_tps_for_claim_denominator": claim_pg_tps,
+            "ratio_percent_vs_pg_reference": ratio_vs_pg_reference,
             "pg_payment_p95_ms": pg_payment_p95,
             "postgres_new_order_share": pg_share,
             "rustdb_new_order_share": rd_share,

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -784,7 +784,7 @@ fn insert_rows_tuple_tpcc_deferred_inner(
     ctx: &mut SessionContext,
     table: &str,
     tuples: &[Tuple],
-    shard_w_id: i32,
+    heap_shard_key: i32,
     profile: bool,
 ) -> Result<(TpccInsertTimings, TpccDeferredInsertBreakdown), EngineError> {
     let empty = || {
@@ -823,7 +823,7 @@ fn insert_rows_tuple_tpcc_deferred_inner(
     }
     let encode_us = t_encode.map(phase_elapsed_us).unwrap_or(0);
 
-    let storage_key = tpcc_heap_storage_key(table, shard_w_id);
+    let storage_key = tpcc_heap_storage_key(table, heap_shard_key);
     let pm_for_table = table_page_manager_cached_storage(state, ctx, &storage_key)?;
 
     let t_heap = profile.then(Instant::now);
@@ -888,14 +888,14 @@ pub(crate) fn insert_row_tuple_tpcc_deferred(
     ctx: &mut SessionContext,
     table: &str,
     tuple: Tuple,
-    shard_w_id: i32,
+    heap_shard_key: i32,
 ) -> Result<TpccInsertTimings, EngineError> {
     let (timings, _) = insert_rows_tuple_tpcc_deferred_inner(
         state,
         ctx,
         table,
         std::slice::from_ref(&tuple),
-        shard_w_id,
+        heap_shard_key,
         false,
     )?;
     Ok(timings)
@@ -907,10 +907,10 @@ pub(crate) fn insert_rows_tuple_tpcc_deferred_batch(
     ctx: &mut SessionContext,
     table: &str,
     tuples: &[Tuple],
-    shard_w_id: i32,
+    heap_shard_key: i32,
 ) -> Result<TpccInsertTimings, EngineError> {
     let (timings, _) =
-        insert_rows_tuple_tpcc_deferred_inner(state, ctx, table, tuples, shard_w_id, false)?;
+        insert_rows_tuple_tpcc_deferred_inner(state, ctx, table, tuples, heap_shard_key, false)?;
     Ok(timings)
 }
 
@@ -920,14 +920,14 @@ pub(crate) fn insert_row_tuple_tpcc_deferred_breakdown(
     ctx: &mut SessionContext,
     table: &str,
     tuple: Tuple,
-    shard_w_id: i32,
+    heap_shard_key: i32,
 ) -> Result<(TpccInsertTimings, TpccDeferredInsertBreakdown), EngineError> {
     insert_rows_tuple_tpcc_deferred_inner(
         state,
         ctx,
         table,
         std::slice::from_ref(&tuple),
-        shard_w_id,
+        heap_shard_key,
         true,
     )
 }
@@ -938,9 +938,9 @@ pub(crate) fn insert_rows_tuple_tpcc_deferred_batch_breakdown(
     ctx: &mut SessionContext,
     table: &str,
     tuples: &[Tuple],
-    shard_w_id: i32,
+    heap_shard_key: i32,
 ) -> Result<(TpccInsertTimings, TpccDeferredInsertBreakdown), EngineError> {
-    insert_rows_tuple_tpcc_deferred_inner(state, ctx, table, tuples, shard_w_id, true)
+    insert_rows_tuple_tpcc_deferred_inner(state, ctx, table, tuples, heap_shard_key, true)
 }
 
 fn insert_row_tuple_tpcc_immediate(
@@ -1769,11 +1769,19 @@ pub(crate) fn tpcc_order_line_shard_count() -> u32 {
         .max(1)
 }
 
+/// Maps a native-bench district id to a physical `order_line~N` heap index.
+pub(crate) fn tpcc_order_line_shard_index(d_id: i32, shards: u32) -> u32 {
+    ((d_id.max(1) as u32).saturating_sub(1)) % shards.max(1)
+}
+
 /// Physical heap key for native TPC-C DML (logical table name unchanged for catalog/index/WAL).
-pub(crate) fn tpcc_heap_storage_key(table: &str, w_id: i32) -> String {
+///
+/// For `order_line` with `RUSTDB_TPCC_ORDER_LINE_SHARDS` > 1, `heap_shard_key` must be the row's
+/// `ol_d_id` (native bench uses `w_id = 1` always, so sharding by `w_id` would not spread load).
+pub(crate) fn tpcc_heap_storage_key(table: &str, heap_shard_key: i32) -> String {
     let shards = tpcc_order_line_shard_count();
     if table == "order_line" && shards > 1 {
-        let shard = ((w_id.max(1) as u32) - 1) % shards;
+        let shard = tpcc_order_line_shard_index(heap_shard_key, shards);
         format!("order_line~{shard}")
     } else {
         table.to_string()
@@ -5546,6 +5554,21 @@ mod tests {
             "COMMIT should skip heap flush when RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT=1"
         );
         std::env::remove_var("RUSTDB_DEFER_HEAP_FLUSH_ON_COMMIT");
+    }
+
+    #[test]
+    fn tpcc_order_line_shard_index_by_district() {
+        assert_eq!(tpcc_order_line_shard_index(1, 5), 0);
+        assert_eq!(tpcc_order_line_shard_index(5, 5), 4);
+        assert_eq!(tpcc_order_line_shard_index(3, 16), 2);
+        assert_eq!(tpcc_order_line_shard_index(0, 5), 0);
+
+        std::env::set_var("RUSTDB_TPCC_ORDER_LINE_SHARDS", "5");
+        assert_eq!(tpcc_heap_storage_key("order_line", 1), "order_line~0");
+        assert_eq!(tpcc_heap_storage_key("order_line", 5), "order_line~4");
+        assert_eq!(tpcc_heap_storage_key("oorder", 1), "oorder");
+        std::env::remove_var("RUSTDB_TPCC_ORDER_LINE_SHARDS");
+        assert_eq!(tpcc_heap_storage_key("order_line", 3), "order_line");
     }
 
     #[test]

--- a/src/network/sql_engine/tpcc_native.rs
+++ b/src/network/sql_engine/tpcc_native.rs
@@ -223,7 +223,7 @@ fn run_new_order_native(
             ctx,
             "order_line",
             &order_line_tuples,
-            w_id,
+            d_id,
         )?;
         wal_insert_us += ins.wal_us;
         index_sync_us += ins.index_us;
@@ -240,7 +240,7 @@ fn run_new_order_native(
             ctx,
             "order_line",
             &order_line_tuples,
-            w_id,
+            d_id,
         )?;
         wal_insert_us += ins.wal_us;
         index_sync_us += ins.index_us;


### PR DESCRIPTION
## Summary
- Shard native `order_line` inserts by `ol_d_id` instead of `w_id` (native bench always uses `w_id=1`, so w_id sharding never spread load).
- Add `tpcc_order_line_shard_index()` and unit test; pass `d_id` from `run_new_order_native`.
- Enable `RUSTDB_TPCC_ORDER_LINE_SHARDS=5` in CI full-mix bench (matches 5 districts in `tpcc_seed.sql`); microbench default 5.

## Why
Full-mix CI showed ~93 ms p50 on `insert_order_line_pm_lock_wait_us` with a single heap mutex. Five district-scoped heaps should cut lock contention ~5× for native new_order.

## Test plan
- [x] `cargo test --lib tpcc_order_line_shard_index_by_district`
- [ ] CI TPC-C bench: compare `insert_order_line_pm_lock_wait_us` p50/p95 vs run 26845065968
- [ ] Local: `bash scripts/tpcc_order_line_insert_microbench.sh` with `ORDER_LINE_CNT=1`
