### PR TITLE
perf(tpcc): shard oorder heap by district id

### DIFF
--- a/scripts/tpcc_throughput_ci.sh
+++ b/scripts/tpcc_throughput_ci.sh
@@ -35,7 +35,7 @@
 #     engine fast path: direct index/heap ops + single COMMIT, not 7× SQL per new_order)
 #   RUSTDB_TPCC_NATIVE_MICRO=1 — after the main run, run a short native-only micro leg
 #     (order_status-heavy mix, fewer txns) written to tpcc-native-micro.json
-#   RUSTDB_TPCC_ORDER_LINE_SHARDS — native order_line heap shards by ol_d_id (default 1;
+#   RUSTDB_TPCC_ORDER_LINE_SHARDS — native order_line/oorder heap shards by district id (default 1;
 #     CI/microbench use 5 to match tpcc_seed districts)
 #
 set -euo pipefail

--- a/src/network/sql_engine/mod.rs
+++ b/src/network/sql_engine/mod.rs
@@ -1760,7 +1760,7 @@ pub(crate) fn table_page_manager(
     Ok(pm)
 }
 
-/// Shard count for native `order_line` heap files (`order_line~N.tbl`). Default `1` = single heap.
+/// Shard count for native TPC-C heap files (`order_line~N`, `oorder~N`). Default `1` = single heap.
 pub(crate) fn tpcc_order_line_shard_count() -> u32 {
     std::env::var("RUSTDB_TPCC_ORDER_LINE_SHARDS")
         .ok()
@@ -1769,20 +1769,20 @@ pub(crate) fn tpcc_order_line_shard_count() -> u32 {
         .max(1)
 }
 
-/// Maps a native-bench district id to a physical `order_line~N` heap index.
+/// Maps a native-bench district id to a physical sharded heap index (`~N` suffix).
 pub(crate) fn tpcc_order_line_shard_index(d_id: i32, shards: u32) -> u32 {
     ((d_id.max(1) as u32).saturating_sub(1)) % shards.max(1)
 }
 
 /// Physical heap key for native TPC-C DML (logical table name unchanged for catalog/index/WAL).
 ///
-/// For `order_line` with `RUSTDB_TPCC_ORDER_LINE_SHARDS` > 1, `heap_shard_key` must be the row's
-/// `ol_d_id` (native bench uses `w_id = 1` always, so sharding by `w_id` would not spread load).
+/// For `order_line` / `oorder` with `RUSTDB_TPCC_ORDER_LINE_SHARDS` > 1, `heap_shard_key` must be
+/// the row's district id (`ol_d_id` / `o_d_id`; native bench uses `w_id = 1` always).
 pub(crate) fn tpcc_heap_storage_key(table: &str, heap_shard_key: i32) -> String {
     let shards = tpcc_order_line_shard_count();
-    if table == "order_line" && shards > 1 {
+    if shards > 1 && (table == "order_line" || table == "oorder") {
         let shard = tpcc_order_line_shard_index(heap_shard_key, shards);
-        format!("order_line~{shard}")
+        format!("{table}~{shard}")
     } else {
         table.to_string()
     }
@@ -5566,9 +5566,11 @@ mod tests {
         std::env::set_var("RUSTDB_TPCC_ORDER_LINE_SHARDS", "5");
         assert_eq!(tpcc_heap_storage_key("order_line", 1), "order_line~0");
         assert_eq!(tpcc_heap_storage_key("order_line", 5), "order_line~4");
-        assert_eq!(tpcc_heap_storage_key("oorder", 1), "oorder");
+        assert_eq!(tpcc_heap_storage_key("oorder", 1), "oorder~0");
+        assert_eq!(tpcc_heap_storage_key("oorder", 5), "oorder~4");
         std::env::remove_var("RUSTDB_TPCC_ORDER_LINE_SHARDS");
         assert_eq!(tpcc_heap_storage_key("order_line", 3), "order_line");
+        assert_eq!(tpcc_heap_storage_key("oorder", 3), "oorder");
     }
 
     #[test]

--- a/src/network/sql_engine/tpcc_native.rs
+++ b/src/network/sql_engine/tpcc_native.rs
@@ -133,7 +133,7 @@ fn run_new_order_native(
                 ("o_ol_cnt", 1),
             ],
         ),
-        w_id,
+        d_id,
     )?;
     wal_insert_us += ins.wal_us;
     index_sync_us += ins.index_us;


### PR DESCRIPTION
## Summary
- Extend \	pcc_heap_storage_key\ to shard \oorder\ into \oorder~N\ physical heaps (same \RUSTDB_TPCC_ORDER_LINE_SHARDS\ env as \order_line\).
- Pass \o_d_id\ as heap shard key in native \
ew_order\ (was \w_id=1\, which did not spread lock contention).
- CI run on PR #94 showed \insert_oorder_us\ p50 ~64ms as the next bottleneck after order_line sharding.

## Test plan
- [x] \cargo test tpcc_order_line_shard_index_by_district\`n- [ ] CI TPC-C bench: expect lower \insert_oorder_us\ p50/p95 vs PR #94 baseline

Made with [Cursor](https://cursor.com)